### PR TITLE
Add CaraML docs sync workflow

### DIFF
--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -1,0 +1,22 @@
+# This workflow triggers sync of docs to caraml-dev/docs
+
+name: Trigger CaraML Docs Sync
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  trigger-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Remote Doc Sync Workflow
+        uses: caraml-dev/docs/.github/actions/trigger-remote-docs-sync@main
+        with:
+          module: 'router'
+          git_https: 'https://github.com/caraml-dev/turing.git'
+          doc_folder: 'docs'
+          ref_name: ${{ github.ref_name }}
+          ref_type: ${{ github.ref_type }}
+          credentials: ${{ secrets.CARAML_SYNC }}


### PR DESCRIPTION
**What this PR does / why we need it**:
With the migration of `turing` to the CaraML organisation, we are syncing the docs from `turing` automatically to https://github.com/caraml-dev/docs. 

This PR introduces an additional workflow which performs this step, which can be found here: https://github.com/caraml-dev/docs/tree/main/.github/actions/trigger-remote-docs-sync

**Which issue(s) this PR fixes**:
None
