### PR TITLE
Add turing_req_id in requests made to Turing Router components

### DIFF
--- a/docs/how-to/create-a-router/configure-enricher.md
+++ b/docs/how-to/create-a-router/configure-enricher.md
@@ -12,7 +12,7 @@ Original request will be sent to configured routes without enrichment.
 ### Docker
 Turing will deploy specified Docker image as a pre-processor and will send original request to it for enrichment. 
 
-The request to the enricher is constructed from the request headers to the Router, and an identifier `turing_req_id` 
+The request to the enricher is constructed from the request headers to the Router, and an identifier `Turing-Req-Id` 
 that is uniquely assigned to each request received by the Router.
 
 To configure a Docker enricher, there are 3 sections to fill.  

--- a/docs/how-to/create-a-router/configure-enricher.md
+++ b/docs/how-to/create-a-router/configure-enricher.md
@@ -10,7 +10,12 @@ The Turing enricher has the ability to perform arbitrary transformations on the 
 Original request will be sent to configured routes without enrichment.
 
 ### Docker
-Turing will deploy specified Docker image as a pre-processor and will send original request to it for enrichment. To configure a Docker enricher, there are 3 sections to fill.  
+Turing will deploy specified Docker image as a pre-processor and will send original request to it for enrichment. 
+
+The request to the enricher is constructed from the request headers to the Router, and an identifier `turing_req_id` 
+that is uniquely assigned to each request received by the Router.
+
+To configure a Docker enricher, there are 3 sections to fill.  
 
 Configure the Docker Container. There are 4 required inputs.
 

--- a/docs/how-to/create-a-router/configure-ensembler.md
+++ b/docs/how-to/create-a-router/configure-ensembler.md
@@ -26,7 +26,14 @@ It is not possible to select as the fallback response a route that has traffic r
 {% endhint %}
 
 ## Docker
-Turing will deploy the specified image as a post-processor and will send in the request payload the following, for ensembling - the original request, responses from all routes, and the treatment configuration (if an Experiment Engine is selected, in Configure Experiment Engine). The ensembler's request headers will contain the original request headers sent to Turing, merged with the enricher's response headers (if there are duplicates, the value in the enricher's response headers will take precedence). To configure a Docker ensembler, there are 3 sections to be filled.
+
+Turing will deploy the specified image as a post-processor and will send in the request payload the following, for 
+ensembling - the original request, responses from all routes, and the treatment configuration (if an Experiment 
+Engine is selected, in the Configure Experiment Engine step). The ensembler's request headers will contain the original 
+request headers sent to Turing, merged with the enricher's response headers (if there are duplicates, the value in 
+the enricher's response headers will take precedence), and an identifier `turing_req_id` that is uniquely assigned to each request received by the Router. 
+
+To configure a Docker ensembler, there are 3 sections to be filled.
 
 Configure the Docker Container. There are 4 required inputs.
 
@@ -57,7 +64,7 @@ Configure the resources required for the ensembler. There are 3 required inputs,
 **Min/Max Replicas**: Min/max number of replicas for your ensembler. Scaling of the ensembler based on traffic volume will be automatically done for you.
 
 ## Pyfunc Ensembler
-Turing will deploy a previously registered pyfunc ensembler (refer to 
+Turing will deploy a previously registered Pyfunc ensembler (refer to 
 [the samples](https://github.com/caraml-dev/turing/tree/main/sdk/samples) in the SDK section for more information on how to 
 deploy one) as a containerised web service. 
 
@@ -65,12 +72,18 @@ This allows you to simply define the logic required for the ensembling
 step by implementing a Python `mlflow`-based interface, and rely on Turing API to containerise and package your 
 implementation as an entire web service automatically.
 
+Similar to requests sent to a Docker Ensembler, the request payload sent to a Pyfunc ensembler will contain the 
+original request, responses from all routes, and the treatment configuration (if an Experiment
+Engine is selected, in the Configure Experiment Engine step). The ensembler's request headers will contain the original
+request headers sent to Turing, merged with the enricher's response headers (if there are duplicates, the value in
+the enricher's response headers will take precedence), and an identifier `turing_req_id` that is uniquely assigned to each request received by the Router. 
+
 To configure your router with a Pyfunc ensembler, simply select from the drop down list your desired ensembler, 
 registered in your current project. You'll also need to indicate your desired timeout value and resource request values:
 
 ![](../../.gitbook/assets/pyfunc_ensembler_config.png)
 
-**Pyfunc Ensembler**: The name of the pyfunc ensembler that has been deployed in your *current* project 
+**Pyfunc Ensembler**: The name of the Pyfunc ensembler that has been deployed in your *current* project 
 
 **Timeout**: Request timeout, which when exceeded, the request to the ensembler will be terminated
 
@@ -87,7 +100,8 @@ The router will send responses from all routes, together with treatment configur
 
 
 ## Ensembler Request Payload Format
-When the ensembler type is Docker/External, the ensembler will receive the following information in the request payload and the behaviour of the ensembler is up to the implementer.
+When the ensembler type is Docker/Pyfunc/External, the ensembler will receive the following information in the request 
+payload and the behaviour of the ensembler is up to the implementer.
 
 ```json
 {

--- a/docs/how-to/create-a-router/configure-ensembler.md
+++ b/docs/how-to/create-a-router/configure-ensembler.md
@@ -31,7 +31,7 @@ Turing will deploy the specified image as a post-processor and will send in the 
 ensembling - the original request, responses from all routes, and the treatment configuration (if an Experiment 
 Engine is selected, in the Configure Experiment Engine step). The ensembler's request headers will contain the original 
 request headers sent to Turing, merged with the enricher's response headers (if there are duplicates, the value in 
-the enricher's response headers will take precedence), and an identifier `turing_req_id` that is uniquely assigned to each request received by the Router. 
+the enricher's response headers will take precedence), and an identifier `Turing-Req-Id` that is uniquely assigned to each request received by the Router. 
 
 To configure a Docker ensembler, there are 3 sections to be filled.
 
@@ -76,7 +76,7 @@ Similar to requests sent to a Docker Ensembler, the request payload sent to a Py
 original request, responses from all routes, and the treatment configuration (if an Experiment
 Engine is selected, in the Configure Experiment Engine step). The ensembler's request headers will contain the original
 request headers sent to Turing, merged with the enricher's response headers (if there are duplicates, the value in
-the enricher's response headers will take precedence), and an identifier `turing_req_id` that is uniquely assigned to each request received by the Router. 
+the enricher's response headers will take precedence), and an identifier `Turing-Req-Id` that is uniquely assigned to each request received by the Router. 
 
 To configure your router with a Pyfunc ensembler, simply select from the drop down list your desired ensembler, 
 registered in your current project. You'll also need to indicate your desired timeout value and resource request values:

--- a/docs/how-to/create-a-router/configure-experiment-engine.md
+++ b/docs/how-to/create-a-router/configure-experiment-engine.md
@@ -5,7 +5,7 @@ This step is **optional** and the default behaviour will be to send the request 
 {% endhint %}
 
 The request sent to the experiment engine is constructed from the request headers to the Router (including an
-identifier `turing_req_id` that is uniquely assigned to each request received by the Router), and either the request 
+identifier `Turing-Req-Id` that is uniquely assigned to each request received by the Router), and either the request 
 body to the Router (if there is no Enricher) or the response body from the Enricher (if enabled).
 
 If you intend to determine how to select/combine responses from the individual routes (typically in the Ensembler) to send back as the Turing response, configure the Experiment Engine as shown in Configure Experiment Engine. 

--- a/docs/how-to/create-a-router/configure-experiment-engine.md
+++ b/docs/how-to/create-a-router/configure-experiment-engine.md
@@ -4,6 +4,10 @@
 This step is **optional** and the default behaviour will be to send the request to all of the configured routes, but the response from Turing will depend on the Ensembler configuration.
 {% endhint %}
 
+The request sent to the experiment engine is constructed from the request headers to the Router (including an
+identifier `turing_req_id` that is uniquely assigned to each request received by the Router), and either the request 
+body to the Router (if there is no Enricher) or the response body from the Enricher (if enabled).
+
 If you intend to determine how to select/combine responses from the individual routes (typically in the Ensembler) to send back as the Turing response, configure the Experiment Engine as shown in Configure Experiment Engine. 
 
 ![](../../.gitbook/assets/configure_expriement_engine.png)

--- a/docs/how-to/create-a-router/configure-routes.md
+++ b/docs/how-to/create-a-router/configure-routes.md
@@ -2,6 +2,10 @@
 
 Routes are an essential part of your Turing Router setup. Each route is defined by its ID and the endpoint. A route can be your deployed ML model, exposed via HTTP interface, or an arbitrary non-ML web-service. Each router should be configured with at least one route and each route's ID should be unique among other routes of this router.
 
+The request sent to the each route is constructed from the request headers to the Router (including an
+identifier `turing_req_id` that is uniquely assigned to each request received by the Router), and either the request
+body to the Router (if there is no Enricher) or the response body from the Enricher (if enabled).
+
 ![](../../.gitbook/assets/routes_panel.png)
 
 {% hint style="info" %}

--- a/docs/how-to/create-a-router/configure-routes.md
+++ b/docs/how-to/create-a-router/configure-routes.md
@@ -3,7 +3,7 @@
 Routes are an essential part of your Turing Router setup. Each route is defined by its ID and the endpoint. A route can be your deployed ML model, exposed via HTTP interface, or an arbitrary non-ML web-service. Each router should be configured with at least one route and each route's ID should be unique among other routes of this router.
 
 The request sent to the each route is constructed from the request headers to the Router (including an
-identifier `turing_req_id` that is uniquely assigned to each request received by the Router), and either the request
+identifier `Turing-Req-Id` that is uniquely assigned to each request received by the Router), and either the request
 body to the Router (if there is no Enricher) or the response body from the Enricher (if enabled).
 
 ![](../../.gitbook/assets/routes_panel.png)

--- a/engines/router/go.mod
+++ b/engines/router/go.mod
@@ -5,11 +5,11 @@ go 1.18
 require (
 	bou.ke/monkey v1.0.2
 	cloud.google.com/go/bigquery v1.14.0
+	github.com/caraml-dev/turing/engines/experiment v0.0.0
 	github.com/fluent/fluent-logger-golang v1.5.0
 	github.com/go-playground/validator/v10 v10.3.0
 	github.com/gojek/fiber v0.0.0-20201008181849-4f0f8284dc84
 	github.com/gojek/mlp v1.4.7
-	github.com/caraml-dev/turing/engines/experiment v0.0.0
 	github.com/google/go-cmp v0.5.5
 	github.com/google/uuid v1.1.2
 	github.com/heptiolabs/healthcheck v0.0.0-20180807145615-6ff867650f40

--- a/engines/router/missionctl/handlers/batch_http_handler.go
+++ b/engines/router/missionctl/handlers/batch_http_handler.go
@@ -2,7 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"sync"
@@ -62,7 +62,7 @@ func (h *batchHTTPHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) 
 	}
 
 	// Read the request body
-	requestBody, err := ioutil.ReadAll(req.Body)
+	requestBody, err := io.ReadAll(req.Body)
 	if err != nil {
 		h.error(ctx, rw, errors.NewHTTPError(err))
 		return

--- a/engines/router/missionctl/handlers/batch_http_handler_test.go
+++ b/engines/router/missionctl/handlers/batch_http_handler_test.go
@@ -2,7 +2,7 @@ package handlers
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -25,7 +25,7 @@ func TestNewBatchHTTPHandler(t *testing.T) {
 
 	//Create test routes endpoint. Route will write request body as response
 	testRouterHandler := http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		requestBody, err := ioutil.ReadAll(request.Body)
+		requestBody, err := io.ReadAll(request.Body)
 		assert.NoError(t, err)
 		_, err = writer.Write(requestBody)
 		assert.NoError(t, err)
@@ -101,7 +101,7 @@ func TestNewBatchHTTPHandler(t *testing.T) {
 			batchHTTPHandler.ServeHTTP(w, req)
 			res := w.Result()
 			defer res.Body.Close()
-			result, _ := ioutil.ReadAll(res.Body)
+			result, _ := io.ReadAll(res.Body)
 
 			assert.Equal(t, test.expectedStatusCode, res.StatusCode)
 			assert.Equal(t, test.expectedContentType, res.Header.Get("Content-Type"))

--- a/engines/router/missionctl/handlers/http_handler.go
+++ b/engines/router/missionctl/handlers/http_handler.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -174,7 +174,7 @@ func (h *httpHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	// Read the request body
-	requestBody, err := ioutil.ReadAll(req.Body)
+	requestBody, err := io.ReadAll(req.Body)
 	if err != nil {
 		h.error(ctx, rw, errors.NewHTTPError(err))
 		return

--- a/engines/router/missionctl/handlers/http_handler.go
+++ b/engines/router/missionctl/handlers/http_handler.go
@@ -161,6 +161,10 @@ func (h *httpHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 	ctxLogger.Debugf("Received request for %v", turingReqID)
 
+	// Sets the turing request id in the header of the original request so that it gets sent to the enricher,
+	// the experiment engine, the model routes, and the ensembler
+	req.Header.Set(turingReqIDHeaderKey, turingReqID)
+
 	if tracing.Glob().IsEnabled() {
 		var sp opentracing.Span
 		ctx, sp = h.enableTracingSpan(ctx, req, httpHandlerID)

--- a/engines/router/missionctl/handlers/http_handler_test.go
+++ b/engines/router/missionctl/handlers/http_handler_test.go
@@ -192,7 +192,8 @@ func TestHTTPService(t *testing.T) {
 
 	// Check that ensembler was called with the expected headers
 	mc.AssertCalled(t, "Ensemble",
-		http.Header{"Context-Type": []string{"application/json"}, "Enricher": []string{"value"}})
+		http.Header{"Context-Type": []string{"application/json"}, "Enricher": []string{"value"},
+			"Turing-Req-Id": []string{rr.Header().Get("Turing-Req-Id")}})
 }
 
 // TestHTTPServiceBadRequest tests for a HTTP InternalServerError on bad

--- a/engines/router/missionctl/http/response.go
+++ b/engines/router/missionctl/http/response.go
@@ -1,7 +1,7 @@
 package http
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -32,7 +32,7 @@ func (r *CachedResponse) Body() []byte {
 // a HTTP response as input
 func NewCachedResponseFromHTTP(r *http.Response) (*CachedResponse, error) {
 	// Consume response body
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/engines/router/missionctl/internal/testutils/utils.go
+++ b/engines/router/missionctl/internal/testutils/utils.go
@@ -1,7 +1,7 @@
 package testutils
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 )
 
@@ -14,7 +14,7 @@ func ReadFile(filepath string) ([]byte, error) {
 	}
 	defer fileObj.Close()
 	// Read contents
-	byteValue, err := ioutil.ReadAll(fileObj)
+	byteValue, err := io.ReadAll(fileObj)
 	if err != nil {
 		return nil, err
 	}

--- a/engines/router/missionctl/log/resultlog/bigquery_test.go
+++ b/engines/router/missionctl/log/resultlog/bigquery_test.go
@@ -3,7 +3,7 @@ package resultlog
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"path/filepath"
 	"testing"
 	"time"
@@ -102,7 +102,7 @@ func TestCheckTableSchema(t *testing.T) {
 func TestBigQueryLoggerGetData(t *testing.T) {
 	// Make test request
 	req := tu.MakeTestRequest(t, tu.NopHTTPRequestModifier)
-	reqBody, err := ioutil.ReadAll(req.Body)
+	reqBody, err := io.ReadAll(req.Body)
 	tu.FailOnError(t, err)
 
 	// Make test context

--- a/engines/router/missionctl/log/resultlog/console_test.go
+++ b/engines/router/missionctl/log/resultlog/console_test.go
@@ -3,7 +3,7 @@ package resultlog
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -33,7 +33,7 @@ func TestNewConsoleLogger(t *testing.T) {
 func TestConsoleLoggerWrite(t *testing.T) {
 	// Make test request
 	req := tu.MakeTestRequest(t, tu.NopHTTPRequestModifier)
-	reqBody, err := ioutil.ReadAll(req.Body)
+	reqBody, err := io.ReadAll(req.Body)
 	tu.FailOnError(t, err)
 
 	// Make test context

--- a/engines/router/missionctl/log/resultlog/resultlog_test.go
+++ b/engines/router/missionctl/log/resultlog/resultlog_test.go
@@ -3,7 +3,7 @@ package resultlog
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -226,7 +226,7 @@ func setGlobalLogger(l TuringResultLogger) {
 func makeTestTuringResultLogEntry(t *testing.T) (context.Context, *TuringResultLogEntry) {
 	// Make test request
 	req := tu.MakeTestRequest(t, tu.NopHTTPRequestModifier)
-	reqBody, err := ioutil.ReadAll(req.Body)
+	reqBody, err := io.ReadAll(req.Body)
 	tu.FailOnError(t, err)
 
 	// Make test context

--- a/sdk/samples/router/create_router_with_pyfunc_ensembler.py
+++ b/sdk/samples/router/create_router_with_pyfunc_ensembler.py
@@ -55,7 +55,10 @@ class SampleEnsembler(turing.ensembler.PyFunc):
         if "version" in input:
             return predictions[input["version"]]["data"]["value"]
         elif "Version" in kwargs["headers"]:
-            return predictions[kwargs["headers"]["Version"]]["data"]["value"]
+            if hash(kwargs["headers"]["Turing-Req-Id"]) % 2 == 0:  # If the hash of the turing request id is even
+                return predictions[kwargs["headers"]["Version"]]["data"]["value"]
+            else:
+                return 0
         else:
             return sum(
                 prediction["data"]["value"] for prediction in predictions.values()


### PR DESCRIPTION
## Context
The `turing_req_id` is a unique identifier attached to every response header for each request sent to a Turing Router. However this header is only added just before the response is returned to the user and could instead be sent together as part of requests sent to the other Turing Router components (e.g. enricher, experiments engine, routes, ensembler), allowing users to capitalise on this identifier for other uses (e.g. using the id as a randomisation key).

This PR thus introduces a slight modification to the Turing Router, by adding the `turing_req_id` generated whenever each request is received to all the subsequent request headers that get sent to the other Turing Router components. 

Additionally, this PR replaces the deprecated `ioutil.ReadAll` function with the new `io.ReadAll` function that gets used in various parts of the Turing Router.

## Main Modifications 
- `engines/router/missionctl/handlers/http_handler.go` - Add `turing_req_id` to requests sent to Turing Router components
- `engines/router/missionctl/handlers/http_handler_test.go` - Update unit tests affected by the aforementioned change
- `docs/*` - Add documentation to Turing Router components affected by the aforementioned change 
- `sdk/samples/router/create_router_with_pyfunc_ensembler.py` - Add sample to demonstrate how the `turing_req_id` header can be accessed in a Pyfunc ensembler