### PR TITLE
Update routing strategy for use with Standard Ensemblers

### DIFF
--- a/engines/router/missionctl/fiberapi/fan_in.go
+++ b/engines/router/missionctl/fiberapi/fan_in.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/caraml-dev/turing/engines/experiment/runner"
@@ -165,7 +165,7 @@ func (fanIn *EnsemblingFanIn) collectResponses(
 	// Return successful response
 	resp := http.Response{
 		StatusCode: 200,
-		Body:       ioutil.NopCloser(bytes.NewBuffer(rBytes)),
+		Body:       io.NopCloser(bytes.NewBuffer(rBytes)),
 		Header: http.Header{
 			"Content-Type": []string{"application/json"},
 		},

--- a/engines/router/missionctl/fiberapi/fan_in_test.go
+++ b/engines/router/missionctl/fiberapi/fan_in_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 	"testing"
@@ -223,7 +223,7 @@ func makeTestResponseQueue(endpointNames ...string) fiber.ResponseQueue {
 	// Populate fiber responses into the channel
 	for _, e := range endpointNames {
 		payload := fmt.Sprintf(`{"value": "%s"}`, e)
-		body := ioutil.NopCloser(bytes.NewReader([]byte(payload)))
+		body := io.NopCloser(bytes.NewReader([]byte(payload)))
 		resp := &http.Response{
 			StatusCode: 200,
 			Body:       body,

--- a/engines/router/missionctl/fiberapi/interceptors_test.go
+++ b/engines/router/missionctl/fiberapi/interceptors_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 	"time"
@@ -126,7 +125,7 @@ func (t *mockTracer) StartSpanFromContext(
 	return nil, nil
 }
 func (*mockTracer) InitGlobalTracer(_ string, _ *config.JaegerConfig) (io.Closer, error) {
-	return ioutil.NopCloser(nil), nil
+	return io.NopCloser(nil), nil
 }
 
 // Test that a startTimeKey has been associated to the context
@@ -365,7 +364,7 @@ func createTestFiberResponseQueue(respStatus int) fiber.ResponseQueue {
 	testBody := []byte(`Test Body`)
 	httpResp := http.Response{
 		StatusCode: respStatus,
-		Body:       ioutil.NopCloser(bytes.NewBuffer(testBody)),
+		Body:       io.NopCloser(bytes.NewBuffer(testBody)),
 	}
 	fiberResp := fiberhttp.NewHTTPResponse(&httpResp)
 	queue := fiber.NewResponseQueueFromResponses(fiberResp)

--- a/engines/router/missionctl/fiberapi/routing_policies.go
+++ b/engines/router/missionctl/fiberapi/routing_policies.go
@@ -14,6 +14,7 @@ import (
 type routeSelPolicyCfg struct {
 	DefRoute           string              `json:"default_route_id,omitempty"`
 	ExperimentMappings []experimentMapping `json:"experiment_mappings"`
+	RouteNamePath      string              `json:"route_name_path"`
 }
 
 type expPolicyCfg struct {
@@ -27,6 +28,7 @@ type expPolicyCfg struct {
 type routeSelectionPolicy struct {
 	defaultRoute       string
 	experimentMappings []experimentMapping
+	routeNamePath      string
 }
 
 // ExperimentMapping specifies the route that should be selected for a particular treatment in an experiment
@@ -62,6 +64,7 @@ func newRouteSelectionPolicy(properties json.RawMessage) (*routeSelectionPolicy,
 	return &routeSelectionPolicy{
 		defaultRoute:       routeSelPolicy.DefRoute,
 		experimentMappings: routeSelPolicy.ExperimentMappings,
+		routeNamePath:      routeSelPolicy.RouteNamePath,
 	}, nil
 }
 

--- a/engines/router/missionctl/fiberapi/routing_policies.go
+++ b/engines/router/missionctl/fiberapi/routing_policies.go
@@ -61,6 +61,15 @@ func newRouteSelectionPolicy(properties json.RawMessage) (*routeSelectionPolicy,
 	if err != nil {
 		return nil, errors.Newf(errors.BadConfig, "Failed to parse route selection policy")
 	}
+
+	// Ensure that if ExperimentMappings and RouteNamePath cannot be both set at the same time
+	if len(routeSelPolicy.ExperimentMappings) > 0 && routeSelPolicy.RouteNamePath != "" {
+		return nil, errors.Newf(
+			errors.BadConfig,
+			"Experiment mappings and route name path cannot both be configured together",
+		)
+	}
+
 	return &routeSelectionPolicy{
 		defaultRoute:       routeSelPolicy.DefRoute,
 		experimentMappings: routeSelPolicy.ExperimentMappings,

--- a/engines/router/missionctl/fiberapi/routing_policies_test.go
+++ b/engines/router/missionctl/fiberapi/routing_policies_test.go
@@ -45,7 +45,7 @@ func TestNewRouteSelectionPolicy(t *testing.T) {
 					  "treatment": "treatment-2",
 					  "route": "route-2"
 					}
-				  ]
+				]
 			}`),
 			expectedPolicy: routeSelectionPolicy{
 				defaultRoute: "route-1",
@@ -71,6 +71,27 @@ func TestNewRouteSelectionPolicy(t *testing.T) {
 				routeNamePath: "policy.route_name",
 			},
 			success: true,
+		},
+		"failure | with experiment mappings and route name path": {
+			props: json.RawMessage(`{
+				"default_route_id":  "route-1",
+				"experiment_engine": "Test",
+				"route_name_path": "policy.route_name",	
+				"experiment_mappings": [
+					{
+					  "experiment": "experiment-1",
+					  "treatment": "treatment-1",
+					  "route": "route-1"
+					},
+					{
+					  "experiment": "experiment-1",
+					  "treatment": "treatment-2",
+					  "route": "route-2"
+					}
+				]
+			}`),
+			success: false,
+			err:     "Experiment mappings and route name path cannot both be configured together",
 		},
 		"failure | invalid data": {
 			props:   json.RawMessage(`invalid_data`),

--- a/engines/router/missionctl/fiberapi/routing_policies_test.go
+++ b/engines/router/missionctl/fiberapi/routing_policies_test.go
@@ -60,6 +60,18 @@ func TestNewRouteSelectionPolicy(t *testing.T) {
 			props:   json.RawMessage(`{}`),
 			success: true,
 		},
+		"success | with route name path": {
+			props: json.RawMessage(`{
+				"default_route_id":  "route-1",
+				"experiment_engine": "Test",
+				"route_name_path": "policy.route_name"			
+			}`),
+			expectedPolicy: routeSelectionPolicy{
+				defaultRoute:  "route-1",
+				routeNamePath: "policy.route_name",
+			},
+			success: true,
+		},
 		"failure | invalid data": {
 			props:   json.RawMessage(`invalid_data`),
 			success: false,

--- a/engines/router/missionctl/fiberapi/routing_strategy.go
+++ b/engines/router/missionctl/fiberapi/routing_strategy.go
@@ -3,7 +3,9 @@ package fiberapi
 import (
 	"context"
 	"encoding/json"
+	"strings"
 
+	"github.com/buger/jsonparser"
 	"github.com/caraml-dev/turing/engines/experiment/runner"
 	"github.com/caraml-dev/turing/engines/router/missionctl/errors"
 	"github.com/caraml-dev/turing/engines/router/missionctl/experiment"
@@ -79,6 +81,20 @@ func (r *DefaultTuringRoutingStrategy) SelectRoute(
 			// Stop matching on first match because only 1 route is required. Don't send in fallbacks,
 			// because we do not want to suppress the error from the preferred route.
 			return routes[m.Route], []fiber.Component{}, nil
+		}
+	}
+
+	// Use the route name path to locate the name of the route to be returned as the final response
+	if r.routeSelectionPolicy.routeNamePath != "" {
+		routeName, err := jsonparser.GetString(experimentResponse.Body(), strings.Split(r.routeSelectionPolicy.routeNamePath, ".")...)
+
+		if err != nil {
+			log.WithContext(ctx).Errorf(err.Error())
+			return nil, fallbacks, nil
+		}
+
+		if selectedRoute, ok := routes[routeName]; ok {
+			return selectedRoute, []fiber.Component{}, nil
 		}
 	}
 

--- a/engines/router/missionctl/fiberapi/routing_strategy.go
+++ b/engines/router/missionctl/fiberapi/routing_strategy.go
@@ -76,6 +76,8 @@ func (r *DefaultTuringRoutingStrategy) SelectRoute(
 		return nil, fallbacks, nil
 	}
 
+	// For the DefaultTuringRoutingStrategy, we only expect experimentMappings OR routeNamePath to be configured; we
+	// perform a check on both of them and determine the final route response to return
 	for _, m := range r.experimentMappings {
 		if m.Experiment == expPlan.ExperimentName && m.Treatment == expPlan.Name {
 			// Stop matching on first match because only 1 route is required. Don't send in fallbacks,
@@ -99,6 +101,12 @@ func (r *DefaultTuringRoutingStrategy) SelectRoute(
 		if selectedRoute, ok := routes[routeName]; ok {
 			return selectedRoute, []fiber.Component{}, nil
 		}
+
+		// There are no routes with the route name found in the treatment
+		log.WithContext(ctx).Errorf(
+			"No route found corresponding to the route name found in the treatment:, %s",
+			routeName,
+		)
 	}
 
 	// primary route will be nil if there are no matching treatments in the mapping

--- a/engines/router/missionctl/fiberapi/routing_strategy.go
+++ b/engines/router/missionctl/fiberapi/routing_strategy.go
@@ -86,7 +86,10 @@ func (r *DefaultTuringRoutingStrategy) SelectRoute(
 
 	// Use the route name path to locate the name of the route to be returned as the final response
 	if r.routeSelectionPolicy.routeNamePath != "" {
-		routeName, err := jsonparser.GetString(experimentResponse.Body(), strings.Split(r.routeSelectionPolicy.routeNamePath, ".")...)
+		routeName, err := jsonparser.GetString(
+			experimentResponse.Body(),
+			strings.Split(r.routeSelectionPolicy.routeNamePath, ".")...,
+		)
 
 		if err != nil {
 			log.WithContext(ctx).Errorf(err.Error())

--- a/engines/router/missionctl/fiberapi/routing_strategy_test.go
+++ b/engines/router/missionctl/fiberapi/routing_strategy_test.go
@@ -26,7 +26,7 @@ func TestInitializeDefaultRoutingStrategy(t *testing.T) {
 	}
 
 	tests := map[string]testSuiteInitStrategy{
-		"success": {
+		"success | with experiment mappings": {
 			properties: json.RawMessage(`{
 				"default_route_id":  "route1",
 				"experiment_engine": "Test",
@@ -68,7 +68,24 @@ func TestInitializeDefaultRoutingStrategy(t *testing.T) {
 				},
 			},
 		},
-		"missing_route_policy": {
+		"failure | with route name path": {
+			properties: json.RawMessage(`{
+				"default_route_id":  "route1",
+				"experiment_engine": "Test",
+				"route_name_path": "policy.route_name",
+				"experiment_mappings": [
+					{
+						"experiment": "experiment-1",
+                        "treatment": "control",
+                        "route": "route1"
+					}
+                ]
+			}`),
+			success: false,
+			expectedError: "Failed initializing route selection policy on routing strategy: Experiment mappings and " +
+				"route name path cannot both be configured together",
+		},
+		"failure | missing_route_policy": {
 			properties: json.RawMessage(`{
 				"experiment_engine": "Test"
 			}`),

--- a/engines/router/missionctl/handlers/http_handler_test.go
+++ b/engines/router/missionctl/handlers/http_handler_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -401,7 +401,7 @@ func modifyRequestBody(
 	// Return response
 	httpResponse := &http.Response{
 		StatusCode: 200,
-		Body:       ioutil.NopCloser(bytes.NewBuffer(tBytes)),
+		Body:       io.NopCloser(bytes.NewBuffer(tBytes)),
 		Header:     httpHeader,
 	}
 	mcResp, err := mchttp.NewCachedResponseFromHTTP(httpResponse)

--- a/engines/router/missionctl/http/response_test.go
+++ b/engines/router/missionctl/http/response_test.go
@@ -2,7 +2,7 @@ package http
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -49,7 +49,7 @@ func makeTestHTTPResponse() *http.Response {
 
 	testResp := http.Response{
 		Header: header,
-		Body:   ioutil.NopCloser(bytes.NewReader(body)),
+		Body:   io.NopCloser(bytes.NewReader(body)),
 	}
 
 	return &testResp

--- a/engines/router/missionctl/instrumentation/tracing/nop.go
+++ b/engines/router/missionctl/instrumentation/tracing/nop.go
@@ -3,7 +3,6 @@ package tracing
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/caraml-dev/turing/engines/router/missionctl/config"
@@ -23,7 +22,7 @@ func (*NopTracer) SetStartNewSpans(_ bool) {}
 
 // InitGlobalTracer satisfies the Tracer interface and returns a Nop closer
 func (*NopTracer) InitGlobalTracer(_ string, _ *config.JaegerConfig) (io.Closer, error) {
-	return ioutil.NopCloser(nil), nil
+	return io.NopCloser(nil), nil
 }
 
 // IsEnabled satisfies the Tracer interface, always returning false

--- a/engines/router/missionctl/internal/testutils/response.go
+++ b/engines/router/missionctl/internal/testutils/response.go
@@ -2,7 +2,7 @@ package testutils
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	mchttp "github.com/caraml-dev/turing/engines/router/missionctl/http"
@@ -12,7 +12,7 @@ import (
 func MakeTestMisisonControlResponse() mchttp.Response {
 	httpResponse := &http.Response{
 		StatusCode: http.StatusOK,
-		Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(`{"data": "test"}`))),
+		Body:       io.NopCloser(bytes.NewBuffer([]byte(`{"data": "test"}`))),
 		Header:     http.Header{},
 	}
 	mcResp, _ := mchttp.NewCachedResponseFromHTTP(httpResponse)

--- a/engines/router/missionctl/mission_control.go
+++ b/engines/router/missionctl/mission_control.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -98,7 +98,7 @@ func createNewHTTPRequest(
 ) (*http.Request, error) {
 	// Create new http request with the input body, ctx, url and method
 	req, err := http.NewRequestWithContext(ctx, httpMethod, url,
-		ioutil.NopCloser(bytes.NewReader(body)))
+		io.NopCloser(bytes.NewReader(body)))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Context
Standard Ensemblers allow users to make a Turing Router return a response from one of its routes based on the mapping between routes and experiment treatments. At run time, the treatment returned by the engine will be used to select the corresponding route’s response. A fallback route may also be configured whose results will be used at runtime when the call to the experiment engine fails or if a route mapping for the treatment generated by the experiment engine does not exist.

**To a user, this is the simplest way to set up a final route response given a treatment generated by an experiment engine** - when given a particular treatment, return a specific route response (i.e. if treatment A is received, return the route response from route A).

As of present, Standard Ensemblers are only available for [Standard Experiment Engines](https://github.com/caraml-dev/turing/blob/main/docs/how-to/create-a-router/configure-ensembler.md#standard-ensembler). With the plan to introduce Standard Ensemblers for [Turing Experiments](https://github.com/caraml-dev/xp), while **maintaining the similar and simple workflow for the end user**, there is a need to modify the existing behaviour of the Turing Router, especially since Turing Experiments has been implemented as a [Custom Experiment Engine](https://github.com/caraml-dev/turing/blob/main/engines/experiment/docs/developer_guide.md#custom-experiment-manager).

In particular, as Turing Experiments determines the experiment (and thus treatments) to assign a request to in run time, it is impossible to predetermine the experiment mappings found in the route selection policy of a configured Turing Router during deployment time (as specified in a Turing Router's configuration file). Hence, an alternative to achieve the same outcome is to utilise the route name found within the treatment configuration generated by the experiment engine (via a json path configured by the user in a Turing Router's configuration file) to determine the final route response that the Turing Router should return to its caller. Consider the example below:

```json
{
    ...,
    “policy”: {
        "route_name": "control"
    }
}
```

Given the treatment configuration above, the Turing Router will be expected to return the response corresponding to the route name "control" as the final route response.

This PR thus introduces changes to the `DefaultTuringRoutingStrategy` used by the Turing Router to select the appropriate final response route using the workflow described above. 

## Further Details
The only routing strategy change that is relevant for the aforementioned modification is the `DefaultTuringRoutingStrategy` defined for the `EAGER_ROUTER` of the [fiber](https://github.com/gojek/fiber) library, since there is no need to aggregate all received responses into a single response (as used in a `COMBINER`). 

Future changes to the Turing API (in a separate PR) will reflect this selective change.

## Main Modifications
- `engines/router/missionctl/fiberapi/routing_policies.go` - Addition of a `routeNamePath` to the `routeSelectionPolicy` struct that defines the path where the route name should be found within a treatment configuration
- `engines/router/missionctl/fiberapi/routing_strategy.go` - Addition of extra steps to return the response of a route whose name matches the name found in the `routeNamePath` of a treatment configuration

## Minor Fixes
- Removal of deprecated `io/ioutil` functions and replacing them with those from the `io` package 

