### PR TITLE
Disallow Dangling routes with Traffic rules

### DIFF
--- a/api/turing/validation/validator.go
+++ b/api/turing/validation/validator.go
@@ -139,7 +139,6 @@ func checkDefaultTrafficRule(
 	sl validator.StructLevel,
 	fieldName string,
 	defaultTrafficRule *models.DefaultTrafficRule,
-	defaultRouteID *string,
 ) {
 	defaultTrafficRuleDescription := strings.Join([]string{
 		"Since 1 or more Custom Traffic rules have been specified,",
@@ -148,11 +147,18 @@ func checkDefaultTrafficRule(
 	if defaultTrafficRule == nil {
 		sl.ReportError(defaultTrafficRule, fieldName, "defaultTrafficRule", defaultTrafficRuleDescription, "")
 	}
+}
 
+func validateDefaultTrafficRuleDefaultRoute(
+	sl validator.StructLevel,
+	fieldName string,
+	defaultTrafficRule *models.DefaultTrafficRule,
+	defaultRouteID *string,
+) {
 	// DefaultRouteId should be present in Default Traffic Rule
 	if defaultTrafficRule != nil && defaultRouteID != nil {
 		missingDefaultRouteDescription := fmt.Sprintf(
-			"Fallback Route (DefaultRouteId): '%s' should be associated for the Default Traffic Rule", *defaultRouteID)
+			"Fallback Route (DefaultRouteId): '%s' should be associated to the Default Traffic Rule", *defaultRouteID)
 		containsDefaultRouteID := false
 		for _, route := range defaultTrafficRule.Routes {
 			if route == *defaultRouteID {
@@ -217,7 +223,9 @@ func validateRouterConfig(sl validator.StructLevel) {
 	allRuleRoutesSet := set.New()
 	if routerConfig.TrafficRules != nil {
 		if len(routerConfig.TrafficRules) > 0 {
-			checkDefaultTrafficRule(sl, "DefaultTrafficRule", routerConfig.DefaultTrafficRule, routerConfig.DefaultRouteID)
+			checkDefaultTrafficRule(sl, "DefaultTrafficRule", routerConfig.DefaultTrafficRule)
+			validateDefaultTrafficRuleDefaultRoute(
+				sl, "DefaultTrafficRule", routerConfig.DefaultTrafficRule, routerConfig.DefaultRouteID)
 			if routerConfig.DefaultTrafficRule != nil {
 				for _, route := range routerConfig.DefaultTrafficRule.Routes {
 					allRuleRoutesSet.Insert(route)

--- a/api/turing/validation/validator.go
+++ b/api/turing/validation/validator.go
@@ -6,11 +6,12 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/caraml-dev/turing/engines/router"
+	"github.com/golang-collections/collections/set"
 
 	"github.com/caraml-dev/turing/api/turing/api/request"
 	"github.com/caraml-dev/turing/api/turing/models"
 	"github.com/caraml-dev/turing/api/turing/service"
+	"github.com/caraml-dev/turing/engines/router"
 	"github.com/go-playground/validator/v10"
 	"github.com/go-playground/validator/v10/non-standard/validators"
 )
@@ -138,6 +139,7 @@ func checkDefaultTrafficRule(
 	sl validator.StructLevel,
 	fieldName string,
 	defaultTrafficRule *models.DefaultTrafficRule,
+	defaultRouteID *string,
 ) {
 	defaultTrafficRuleDescription := strings.Join([]string{
 		"Since 1 or more Custom Traffic rules have been specified,",
@@ -145,6 +147,43 @@ func checkDefaultTrafficRule(
 	}, " ")
 	if defaultTrafficRule == nil {
 		sl.ReportError(defaultTrafficRule, fieldName, "defaultTrafficRule", defaultTrafficRuleDescription, "")
+	}
+
+	// DefaultRouteId should be present in Default Traffic Rule
+	if defaultTrafficRule != nil && defaultRouteID != nil {
+		missingDefaultRouteDescription := fmt.Sprintf(
+			"Fallback Route (DefaultRouteId): '%s' should be associated for the Default Traffic Rule", *defaultRouteID)
+		containsDefaultRouteID := false
+		for _, route := range defaultTrafficRule.Routes {
+			if route == *defaultRouteID {
+				containsDefaultRouteID = true
+			}
+		}
+		if !containsDefaultRouteID {
+			sl.ReportError(defaultTrafficRule, fieldName, "defaultTrafficRule", missingDefaultRouteDescription, "")
+		}
+	}
+}
+
+func checkDanglingRoutes(
+	sl validator.StructLevel,
+	fieldName string,
+	allRoutes models.Routes,
+	allRulesRoutes *set.Set,
+) {
+	danglingRoutesDescription :=
+		"These route(s) should be removed since they have no rule associated and will never be called: %s"
+	danglingRoutes := make([]string, 0)
+	for _, route := range allRoutes {
+		if !allRulesRoutes.Has(route.ID) {
+			danglingRoutes = append(danglingRoutes, route.ID)
+		}
+	}
+
+	if len(danglingRoutes) > 0 {
+		sl.ReportError(
+			"", fieldName, "danglingRoutes", fmt.Sprintf(danglingRoutesDescription, strings.Join(danglingRoutes, ",")), "",
+		)
 	}
 }
 
@@ -175,24 +214,55 @@ func validateRouterConfig(sl validator.StructLevel) {
 	}
 
 	// Validate traffic rules
+	allRuleRoutesSet := set.New()
 	if routerConfig.TrafficRules != nil {
 		if len(routerConfig.TrafficRules) > 0 {
-			checkDefaultTrafficRule(sl, "DefaultTrafficRule", routerConfig.DefaultTrafficRule)
+			checkDefaultTrafficRule(sl, "DefaultTrafficRule", routerConfig.DefaultTrafficRule, routerConfig.DefaultRouteID)
+			if routerConfig.DefaultTrafficRule != nil {
+				for _, route := range routerConfig.DefaultTrafficRule.Routes {
+					allRuleRoutesSet.Insert(route)
+				}
+			}
 		}
+		rulesContainDefaultRouteID := true
 		for ruleIdx, rule := range routerConfig.TrafficRules {
 			checkTrafficRuleName(sl, "TrafficRule", rule.Name)
+			containsDefaultRouteID := false
+			// Consider success if DefaultRouteID is not provided
+			if routerConfig.DefaultRouteID == nil {
+				containsDefaultRouteID = true
+			}
 			if rule.Routes != nil {
 				for idx, routeID := range rule.Routes {
+					allRuleRoutesSet.Insert(routeID)
 					ns := fmt.Sprintf("TrafficRules[%d].Routes[%d]", ruleIdx, idx)
 					if err := instance.Var(routeID, fmt.Sprintf("oneof=%s", routeIdsStr)); err != nil {
 						sl.ReportValidationErrors(ns, ns, err.(validator.ValidationErrors))
 					}
 
-					if err := instance.VarWithValue(routeID, routerConfig.DefaultRouteID, "necsfield"); err != nil {
-						sl.ReportValidationErrors(ns, ns, err.(validator.ValidationErrors))
+					// Check if DefaultRouteID is provided
+					if routerConfig.DefaultRouteID != nil && routeID == *routerConfig.DefaultRouteID {
+						containsDefaultRouteID = true
 					}
 				}
 			}
+			if !containsDefaultRouteID {
+				rulesContainDefaultRouteID = false
+			}
 		}
+		// If Traffic Rules are configured, DefaultRouteId should be present in all rules
+		if !rulesContainDefaultRouteID {
+			missingDefaultRouteDescription := fmt.Sprintf(
+				"Fallback Route (DefaultRouteId): '%s' should be associated for all Traffic Rules", *routerConfig.DefaultRouteID,
+			)
+			sl.ReportError(
+				"TrafficRules", "TrafficRules", "DefaultRouteID", missingDefaultRouteDescription, "",
+			)
+		}
+	}
+
+	// Validate dangling routes
+	if routerConfig.TrafficRules != nil && len(routerConfig.TrafficRules) > 0 {
+		checkDanglingRoutes(sl, "Routes", routerConfig.Routes, allRuleRoutesSet)
 	}
 }

--- a/api/turing/validation/validator_test.go
+++ b/api/turing/validation/validator_test.go
@@ -642,7 +642,7 @@ func TestValidateTrafficRules(t *testing.T) {
 			},
 			expectedError: strings.Join([]string{
 				"Key: 'RouterConfig.DefaultTrafficRule' Error:Field validation for 'DefaultTrafficRule' failed on the",
-				"'Fallback Route (DefaultRouteId): 'route-a' should be associated for the Default Traffic Rule' tag",
+				"'Fallback Route (DefaultRouteId): 'route-a' should be associated to the Default Traffic Rule' tag",
 			}, " "),
 		},
 	}

--- a/api/turing/validation/validator_test.go
+++ b/api/turing/validation/validator_test.go
@@ -247,7 +247,7 @@ func TestValidateTrafficRules(t *testing.T) {
 		Timeout:  "10ms",
 	}
 	defaultTrafficRule := &models.DefaultTrafficRule{
-		Routes: []string{"route-b"},
+		Routes: []string{routeAID, routeBID},
 	}
 
 	suite := map[string]routerConfigTestCase{
@@ -266,7 +266,7 @@ func TestValidateTrafficRules(t *testing.T) {
 							Values:      []string{"region-a", "region-b"},
 						},
 					},
-					Routes: []string{"route-b"},
+					Routes: []string{"route-a", "route-b"},
 				},
 			},
 		},
@@ -285,7 +285,7 @@ func TestValidateTrafficRules(t *testing.T) {
 							Values:      []string{"region-a", "region-b"},
 						},
 					},
-					Routes: []string{"route-b"},
+					Routes: []string{"route-a", "route-b"},
 				},
 			},
 		},
@@ -304,7 +304,7 @@ func TestValidateTrafficRules(t *testing.T) {
 							Values:      []string{"region-a", "region-b"},
 						},
 					},
-					Routes: []string{"route-b"},
+					Routes: []string{"route-a", "route-b"},
 				},
 			},
 		},
@@ -316,7 +316,7 @@ func TestValidateTrafficRules(t *testing.T) {
 				{
 					Name:       ruleName,
 					Conditions: []*router.TrafficRuleCondition{},
-					Routes:     []string{"route-b"},
+					Routes:     []string{"route-a"},
 				},
 			},
 			expectedError: "Key: 'RouterConfig.TrafficRules[0].Conditions' " +
@@ -340,8 +340,11 @@ func TestValidateTrafficRules(t *testing.T) {
 					Routes: []string{},
 				},
 			},
-			expectedError: "Key: 'RouterConfig.TrafficRules[0].Routes' " +
-				"Error:Field validation for 'Routes' failed on the 'notBlank' tag",
+			expectedError: strings.Join([]string{
+				"Key: 'RouterConfig.TrafficRules[0].Routes' Error:Field validation for 'Routes' failed on the 'notBlank' tag",
+				"Key: 'RouterConfig.TrafficRules' Error:Field validation for 'TrafficRules' failed on the " +
+					"'Fallback Route (DefaultRouteId): 'route-a' should be associated for all Traffic Rules' tag",
+			}, "\n"),
 		},
 		"failure | unsupported operator": {
 			routes:             models.Routes{routeA, routeB},
@@ -358,7 +361,7 @@ func TestValidateTrafficRules(t *testing.T) {
 							Values:      []string{"region-b"},
 						},
 					},
-					Routes: []string{"route-b"},
+					Routes: []string{"route-a", "route-b"},
 				},
 			},
 			expectedError: "Key: 'RouterConfig.TrafficRules[0].Conditions[0].Operator' " +
@@ -379,7 +382,7 @@ func TestValidateTrafficRules(t *testing.T) {
 							Values:      []string{"region-b"},
 						},
 					},
-					Routes: []string{"route-b"},
+					Routes: []string{"route-a", "route-b"},
 				},
 			},
 			expectedError: "Key: 'RouterConfig.TrafficRules[0].Conditions[0].FieldSource' " +
@@ -400,7 +403,7 @@ func TestValidateTrafficRules(t *testing.T) {
 							Values:      []string{},
 						},
 					},
-					Routes: []string{"route-b"},
+					Routes: []string{"route-a", "route-b"},
 				},
 			},
 			expectedError: "Key: 'RouterConfig.TrafficRules[0].Conditions[0].Field' " +
@@ -436,8 +439,7 @@ func TestValidateTrafficRules(t *testing.T) {
 		"failure | unknown default route": {
 			routes:         models.Routes{routeA},
 			defaultRouteID: &routeBID,
-			expectedError: "Key: 'RouterConfig.DefaultRouteID' " +
-				"Error:Field validation for '' failed on the 'oneof' tag",
+			expectedError:  "Key: 'RouterConfig.DefaultRouteID' Error:Field validation for '' failed on the 'oneof' tag",
 		},
 		"failure | unknown traffic rule route": {
 			routes:             models.Routes{routeA, routeB},
@@ -454,10 +456,10 @@ func TestValidateTrafficRules(t *testing.T) {
 							Values:      []string{"some_value"},
 						},
 					},
-					Routes: []string{"route-c"},
+					Routes: []string{"route-a", "route-c"},
 				},
 			},
-			expectedError: "Key: 'RouterConfig.TrafficRules[0].Routes[0]' " +
+			expectedError: "Key: 'RouterConfig.TrafficRules[0].Routes[1]' " +
 				"Error:Field validation for '' failed on the 'oneof' tag",
 		},
 		"failure | rule does not contains default route": {
@@ -481,8 +483,6 @@ func TestValidateTrafficRules(t *testing.T) {
 				"Key: 'RouterConfig.DefaultTrafficRule' Error:Field validation for " +
 					"'DefaultTrafficRule' failed on the 'Since 1 or more Custom Traffic rules have been specified, " +
 					"a default Traffic rule is required.' tag",
-				"Key: 'RouterConfig.TrafficRules[0].Routes[0]' " +
-					"Error:Field validation for '' failed on the 'necsfield' tag",
 			}, "\n"),
 		},
 		"failure | empty name": {
@@ -510,6 +510,8 @@ func TestValidateTrafficRules(t *testing.T) {
 					"and have no trailing spaces and can contain letters, numbers, blank spaces and the",
 					"following symbols: -_()#$&:.' tag",
 				}, " "),
+				"Key: 'RouterConfig.TrafficRules' Error:Field validation for 'TrafficRules' failed on the " +
+					"'Fallback Route (DefaultRouteId): 'route-a' should be associated for all Traffic Rules' tag",
 			}, "\n"),
 		},
 		"failure | More than 64 characters": {
@@ -527,7 +529,7 @@ func TestValidateTrafficRules(t *testing.T) {
 							Values:      []string{"region-a", "region-b"},
 						},
 					},
-					Routes: []string{"route-b"},
+					Routes: []string{"route-a", "route-b"},
 				},
 			},
 			expectedError: strings.Join([]string{
@@ -552,7 +554,7 @@ func TestValidateTrafficRules(t *testing.T) {
 							Values:      []string{"region-a", "region-b"},
 						},
 					},
-					Routes: []string{"route-b"},
+					Routes: []string{routeAID, routeBID},
 				},
 			},
 			expectedError: strings.Join([]string{
@@ -577,7 +579,7 @@ func TestValidateTrafficRules(t *testing.T) {
 							Values:      []string{"region-a"},
 						},
 					},
-					Routes: []string{routeBID},
+					Routes: []string{routeAID, routeBID},
 				},
 				{
 					Name: "abcd",
@@ -589,7 +591,7 @@ func TestValidateTrafficRules(t *testing.T) {
 							Values:      []string{"region-c"},
 						},
 					},
-					Routes: []string{routeCID},
+					Routes: []string{routeAID, routeCID},
 				},
 			},
 			expectedError: "Key: 'RouterConfig.TrafficRules' " +
@@ -610,12 +612,37 @@ func TestValidateTrafficRules(t *testing.T) {
 							Values:      []string{"region-a", "region-b"},
 						},
 					},
-					Routes: []string{"route-b"},
+					Routes: []string{routeAID, routeBID},
 				},
 			},
 			expectedError: strings.Join([]string{
 				"Key: 'RouterConfig.TrafficRule' Error:Field validation for 'TrafficRule' failed on the",
 				"'default-traffic-rule is a reserved name, and cannot be used as the name for a Custom Traffic Rule.' tag",
+			}, " "),
+		},
+		"failure | missing default route id in default traffic rule": {
+			routes:         models.Routes{routeA, routeB},
+			defaultRouteID: &routeAID,
+			defaultTrafficRule: &models.DefaultTrafficRule{
+				Routes: []string{routeBID},
+			},
+			trafficRules: models.TrafficRules{
+				{
+					Name: ruleName,
+					Conditions: []*router.TrafficRuleCondition{
+						{
+							FieldSource: expRequest.HeaderFieldSource,
+							Field:       "X-Region",
+							Operator:    router.InConditionOperator,
+							Values:      []string{"region-a", "region-b"},
+						},
+					},
+					Routes: []string{"route-a", "route-b"},
+				},
+			},
+			expectedError: strings.Join([]string{
+				"Key: 'RouterConfig.DefaultTrafficRule' Error:Field validation for 'DefaultTrafficRule' failed on the",
+				"'Fallback Route (DefaultRouteId): 'route-a' should be associated for the Default Traffic Rule' tag",
 			}, " "),
 		},
 	}

--- a/api/turing/validation/validator_test.go
+++ b/api/turing/validation/validator_test.go
@@ -343,7 +343,7 @@ func TestValidateTrafficRules(t *testing.T) {
 			expectedError: strings.Join([]string{
 				"Key: 'RouterConfig.TrafficRules[0].Routes' Error:Field validation for 'Routes' failed on the 'notBlank' tag",
 				"Key: 'RouterConfig.TrafficRules' Error:Field validation for 'TrafficRules' failed on the " +
-					"'Fallback Route (DefaultRouteId): 'route-a' should be associated for all Traffic Rules' tag",
+					"'Fallback Route (DefaultRouteId): 'route-a' should be associated to all Traffic Rules' tag",
 			}, "\n"),
 		},
 		"failure | unsupported operator": {
@@ -504,14 +504,14 @@ func TestValidateTrafficRules(t *testing.T) {
 			},
 			expectedError: strings.Join([]string{
 				"Key: 'RouterConfig.TrafficRules[0].Name' Error:Field validation for 'Name' failed on the 'required' tag",
+				"Key: 'RouterConfig.TrafficRules' Error:Field validation for 'TrafficRules' failed on the " +
+					"'Fallback Route (DefaultRouteId): 'route-a' should be associated to all Traffic Rules' tag",
 				strings.Join([]string{
 					"Key: 'RouterConfig.TrafficRule' Error:Field validation for 'TrafficRule' failed on the",
 					"'Name must be between 4-64 characters long, and begin with an alphanumeric character",
 					"and have no trailing spaces and can contain letters, numbers, blank spaces and the",
 					"following symbols: -_()#$&:.' tag",
 				}, " "),
-				"Key: 'RouterConfig.TrafficRules' Error:Field validation for 'TrafficRules' failed on the " +
-					"'Fallback Route (DefaultRouteId): 'route-a' should be associated for all Traffic Rules' tag",
 			}, "\n"),
 		},
 		"failure | More than 64 characters": {
@@ -641,8 +641,8 @@ func TestValidateTrafficRules(t *testing.T) {
 				},
 			},
 			expectedError: strings.Join([]string{
-				"Key: 'RouterConfig.DefaultTrafficRule' Error:Field validation for 'DefaultTrafficRule' failed on the",
-				"'Fallback Route (DefaultRouteId): 'route-a' should be associated to the Default Traffic Rule' tag",
+				"Key: 'RouterConfig.TrafficRules' Error:Field validation for 'TrafficRules' failed on the",
+				"'Fallback Route (DefaultRouteId): 'route-a' should be associated to all Traffic Rules' tag",
 			}, " "),
 		},
 	}

--- a/api/turing/validation/validator_test.go
+++ b/api/turing/validation/validator_test.go
@@ -285,7 +285,7 @@ func TestValidateTrafficRules(t *testing.T) {
 							Values:      []string{"region-a", "region-b"},
 						},
 					},
-					Routes: []string{"route-a", "route-b"},
+					Routes: []string{routeAID, routeBID},
 				},
 			},
 		},
@@ -304,7 +304,7 @@ func TestValidateTrafficRules(t *testing.T) {
 							Values:      []string{"region-a", "region-b"},
 						},
 					},
-					Routes: []string{"route-a", "route-b"},
+					Routes: []string{routeAID, routeBID},
 				},
 			},
 		},
@@ -316,7 +316,7 @@ func TestValidateTrafficRules(t *testing.T) {
 				{
 					Name:       ruleName,
 					Conditions: []*router.TrafficRuleCondition{},
-					Routes:     []string{"route-a"},
+					Routes:     []string{routeAID},
 				},
 			},
 			expectedError: "Key: 'RouterConfig.TrafficRules[0].Conditions' " +
@@ -361,7 +361,7 @@ func TestValidateTrafficRules(t *testing.T) {
 							Values:      []string{"region-b"},
 						},
 					},
-					Routes: []string{"route-a", "route-b"},
+					Routes: []string{routeAID, routeBID},
 				},
 			},
 			expectedError: "Key: 'RouterConfig.TrafficRules[0].Conditions[0].Operator' " +
@@ -382,7 +382,7 @@ func TestValidateTrafficRules(t *testing.T) {
 							Values:      []string{"region-b"},
 						},
 					},
-					Routes: []string{"route-a", "route-b"},
+					Routes: []string{routeAID, routeBID},
 				},
 			},
 			expectedError: "Key: 'RouterConfig.TrafficRules[0].Conditions[0].FieldSource' " +
@@ -403,7 +403,7 @@ func TestValidateTrafficRules(t *testing.T) {
 							Values:      []string{},
 						},
 					},
-					Routes: []string{"route-a", "route-b"},
+					Routes: []string{routeAID, routeBID},
 				},
 			},
 			expectedError: "Key: 'RouterConfig.TrafficRules[0].Conditions[0].Field' " +
@@ -456,7 +456,7 @@ func TestValidateTrafficRules(t *testing.T) {
 							Values:      []string{"some_value"},
 						},
 					},
-					Routes: []string{"route-a", "route-c"},
+					Routes: []string{routeAID, routeCID},
 				},
 			},
 			expectedError: "Key: 'RouterConfig.TrafficRules[0].Routes[1]' " +
@@ -499,7 +499,7 @@ func TestValidateTrafficRules(t *testing.T) {
 							Values:      []string{"region-a", "region-b"},
 						},
 					},
-					Routes: []string{"route-b"},
+					Routes: []string{routeBID},
 				},
 			},
 			expectedError: strings.Join([]string{
@@ -529,7 +529,7 @@ func TestValidateTrafficRules(t *testing.T) {
 							Values:      []string{"region-a", "region-b"},
 						},
 					},
-					Routes: []string{"route-a", "route-b"},
+					Routes: []string{routeAID, routeBID},
 				},
 			},
 			expectedError: strings.Join([]string{
@@ -637,7 +637,7 @@ func TestValidateTrafficRules(t *testing.T) {
 							Values:      []string{"region-a", "region-b"},
 						},
 					},
-					Routes: []string{"route-a", "route-b"},
+					Routes: []string{routeAID, routeBID},
 				},
 			},
 			expectedError: strings.Join([]string{

--- a/ui/src/router/components/form/components/ensembler_config/RouteSelectionPanel.js
+++ b/ui/src/router/components/form/components/ensembler_config/RouteSelectionPanel.js
@@ -49,6 +49,7 @@ export const RouteSelectionPanel = ({
   routeId,
   routes,
   rules,
+  default_traffic_rule,
   onChange,
   errors,
   panelTitle,
@@ -57,6 +58,9 @@ export const RouteSelectionPanel = ({
   const routeOptions = routes
     .filter((e) => !!e.id)
     .map((e) => {
+      const allRules = !!default_traffic_rule ? [...rules, default_traffic_rule] : rules;
+      const isDisabled =
+        !!allRules && allRules.filter((r) => r.routes.includes(e.id)).length !== allRules.length;
       return {
         value: e.id,
         inputDisplay: e.id,
@@ -64,9 +68,11 @@ export const RouteSelectionPanel = ({
           <RouteDropDownOption
             id={e.id}
             endpoint={e.endpoint}
+            isDisabled={isDisabled}
             disabledOptionTooltip="Route with traffic rules cannot be selected"
           />
         ),
+        disabled: isDisabled,
       };
     });
 

--- a/ui/src/router/components/form/components/ensembler_config/RouteSelectionPanel.js
+++ b/ui/src/router/components/form/components/ensembler_config/RouteSelectionPanel.js
@@ -57,8 +57,6 @@ export const RouteSelectionPanel = ({
   const routeOptions = routes
     .filter((e) => !!e.id)
     .map((e) => {
-      const isDisabled =
-        !!rules && rules.filter((r) => r.routes.includes(e.id)).length > 0;
       return {
         value: e.id,
         inputDisplay: e.id,
@@ -66,11 +64,9 @@ export const RouteSelectionPanel = ({
           <RouteDropDownOption
             id={e.id}
             endpoint={e.endpoint}
-            isDisabled={isDisabled}
             disabledOptionTooltip="Route with traffic rules cannot be selected"
           />
         ),
-        disabled: isDisabled,
       };
     });
 

--- a/ui/src/router/components/form/components/ensembler_config/standard_ensembler/StandardEnsemblerFormGroup.js
+++ b/ui/src/router/components/form/components/ensembler_config/standard_ensembler/StandardEnsemblerFormGroup.js
@@ -12,6 +12,7 @@ export const StandardEnsemblerFormGroup = ({
   experimentConfig = {},
   routes,
   rules,
+  default_traffic_rule,
   standardConfig,
   onChangeHandler,
   errors = {},
@@ -60,6 +61,7 @@ export const StandardEnsemblerFormGroup = ({
             routeId={standardConfig.fallback_response_route_id}
             routes={routes}
             rules={rules}
+            default_traffic_rule={default_traffic_rule}
             onChange={onChange("fallback_response_route_id")}
             errors={get(errors, "fallback_response_route_id")}
             panelTitle="Fallback"

--- a/ui/src/router/components/form/components/nop_config/NopConfigFormGroup.js
+++ b/ui/src/router/components/form/components/nop_config/NopConfigFormGroup.js
@@ -8,6 +8,7 @@ import { RouteSelectionPanel } from "../ensembler_config/RouteSelectionPanel";
 export const NopConfigFormGroup = ({
   routes,
   rules,
+  default_traffic_rule,
   nopConfig,
   onChangeHandler,
   errors = {},
@@ -22,6 +23,7 @@ export const NopConfigFormGroup = ({
       <RouteSelectionPanel
         routeId={nopConfig.final_response_route_id}
         routes={routes}
+        default_traffic_rule={default_traffic_rule}
         rules={rules}
         onChange={onChange("final_response_route_id")}
         errors={errors.final_response_route_id}

--- a/ui/src/router/components/form/steps/EnsemblerStep.js
+++ b/ui/src/router/components/form/steps/EnsemblerStep.js
@@ -16,7 +16,7 @@ import ExperimentEngineContext from "../../../../providers/experiments/context";
 export const EnsemblerStep = ({ projectId }) => {
   const {
     data: {
-      config: { experiment_engine, ensembler, routes, rules },
+      config: { experiment_engine, ensembler, routes, rules, default_traffic_rule },
     },
     onChangeHandler,
   } = useContext(FormContext);
@@ -44,6 +44,7 @@ export const EnsemblerStep = ({ projectId }) => {
         <NopConfigFormGroup
           routes={routes}
           rules={rules}
+          default_traffic_rule={default_traffic_rule}
           nopConfig={ensembler.nop_config}
           onChangeHandler={onChange("config.ensembler.nop_config")}
           errors={get(errors, "config.ensembler.nop_config")}
@@ -73,6 +74,7 @@ export const EnsemblerStep = ({ projectId }) => {
           experimentConfig={experiment_engine.config}
           routes={routes}
           rules={rules}
+          default_traffic_rule={default_traffic_rule}
           standardConfig={ensembler.standard_config}
           onChangeHandler={onChange("config.ensembler.standard_config")}
           errors={get(errors, "config.ensembler.standard_config")}

--- a/ui/src/router/components/form/validation/schema.js
+++ b/ui/src/router/components/form/validation/schema.js
@@ -59,6 +59,60 @@ const validateRuleNames = function(items) {
   return !!errors.length ? new yup.ValidationError(errors) : true;
 };
 
+const validateRoutes = function (items) {
+  const defaultTrafficRule = this.options.parent.default_traffic_rule;
+  let trafficRuleRoutes = [...new Set(this.options.parent.rules.map(rule => rule.routes).flat(1))];
+  if (defaultTrafficRule) {
+    trafficRuleRoutes = [...trafficRuleRoutes, ...defaultTrafficRule.routes]
+  }
+
+  const errors = [];
+  items.forEach((item, idx) => {
+    if (!trafficRuleRoutes.includes(item.id)) {
+      errors.push(
+        this.createError({
+          path: `${this.path}[${idx}].id`,
+          message: "This route should be removed since they have no Traffic Rule(s) associated and will never be called.",
+        })
+      );
+    }
+  });
+
+  // Validate Nop/Standard Ensembler
+  const ensembler_type = this.options.parent.ensembler.type
+  // Nop Ensembler
+  let final_fallback_route = "";
+  if (ensembler_type === "nop") {
+    final_fallback_route = this.options.parent.ensembler.nop_config.final_response_route_id;
+  }
+  // Standard Ensembler
+  if (ensembler_type === "standard") {
+    final_fallback_route = this.options.parent.ensembler.standard_config.fallback_response_route_id;
+  }
+
+  let containsFinalFallbackRoute = true;
+  if (final_fallback_route && this.options.parent.rules) {
+    const ruleRoutes = this.options.parent.rules.map(rule => rule.routes);
+    ruleRoutes.forEach((routes) => {
+      if (!routes.includes(final_fallback_route)) {
+        containsFinalFallbackRoute = false;
+      }
+    })
+    if (!containsFinalFallbackRoute) {
+      // Final(Nop)/Fallback(Standard) route should be present in all Traffic Rule routes
+      const invalidRouteIndex = items.findIndex((item) => item.id === final_fallback_route);
+      errors.push(
+        this.createError({
+          path: `${this.path}[${invalidRouteIndex}].id`,
+          message: "Final/Fallback response route should be present in all Traffic Rules.",
+        })
+      );
+    }
+  }
+
+  return !!errors.length ? new yup.ValidationError(errors) : true;
+};
+
 const routerNameRegex = /^[a-z0-9-]*$/,
   durationRegex = /^[0-9]+(ms|s|m|h)$/,
   cpuRequestRegex = /^(\d{1,3}(\.\d{1,3})?)$|^(\d{2,5}m)$/,
@@ -284,7 +338,12 @@ const schema = (maxAllowedReplica) => [
         .array(routeSchema)
         .required()
         .unique("id", "Route Id must be unique")
-        .min(1, "At least one route should be configured"),
+        .min(1, "At least one route should be configured")
+        .when(['rules'], (rules, schema) => {
+          if (rules.length > 0) {
+            return schema.test("no-dangling-routes", validateRoutes);
+          }
+        }),
       default_traffic_rule: yup.object()
         .nullable()
         .when('rules', {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/xp/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/gojek/xp/blob/master/CONTRIBUTING.md#unit-tests
3. Make sure documentation is updated for your PR

-->

**What this PR does / why we need it**:
With the introduction of `Default Traffic Rule` in https://github.com/caraml-dev/turing/pull/232, this PR adds validation to disallow routes that are not associated to any Traffic Rules (a.k.a dangling routes) _**when Traffic rules are specified**_. The motivation is because routes that are not used in any Traffic Rules (if specified), will never be called.

**Validation changes**
`UI`
![image](https://user-images.githubusercontent.com/25025366/190082645-0c34394a-f2f3-457a-bd86-81b430424f47.png)


`API`
<img width="972" alt="image" src="https://user-images.githubusercontent.com/25025366/189828368-25fe9aad-e01c-4fe2-bd31-c2d8b9e5105a.png">


`SDK`
![image](https://user-images.githubusercontent.com/25025366/189828253-0f9b3408-9c84-47c1-bd86-e529db84d29b.png)
