### PR TITLE
[Infra] Expose user-configurable autoscaling parameters

### DIFF
--- a/.github/workflows/cluster-init.yaml
+++ b/.github/workflows/cluster-init.yaml
@@ -55,8 +55,8 @@ jobs:
       CLUSTER_INIT_VERSION: ${{ needs.build-cluster-init.outputs.cluster-init-version }}
       CLUSTER_NAME: turing-e2e
       ISTIO_VERSION: 1.9.9
-      KNATIVE_VERSION: v0.18.3
-      KNATIVE_ISTIO_VERSION: v0.18.1
+      KNATIVE_VERSION: 1.0.1
+      KNATIVE_ISTIO_VERSION: 1.0.0
       LOCAL_REGISTRY: registry.localhost:5000
     needs:
       - build-cluster-init

--- a/api/e2e/test/testdata/create_router_version.json.tmpl
+++ b/api/e2e/test/testdata/create_router_version.json.tmpl
@@ -33,8 +33,8 @@
             "memory_request": "1Gi"
         },
         "autoscaling_policy": {
-            "metric": "rps",
-            "target": "100"
+            "metric": "cpu",
+            "target": "80"
         },
         "endpoint": "anything",
         "timeout": "2s",
@@ -57,8 +57,8 @@
                 "memory_request": "256Mi"
             },
             "autoscaling_policy": {
-                "metric": "rps",
-                "target": "100"
+                "metric": "cpu",
+                "target": "80"
             },
             "endpoint": "anything",
             "timeout": "3s",

--- a/api/e2e/test/testdata/create_router_version.json.tmpl
+++ b/api/e2e/test/testdata/create_router_version.json.tmpl
@@ -57,8 +57,8 @@
                 "memory_request": "256Mi"
             },
             "autoscaling_policy": {
-                "metric": "cpu",
-                "target": "80"
+                "metric": "memory",
+                "target": "220"
             },
             "endpoint": "anything",
             "timeout": "3s",

--- a/api/turing/config/config.go
+++ b/api/turing/config/config.go
@@ -473,7 +473,6 @@ func setDefaultValues(v *viper.Viper) {
 	v.SetDefault("DeployConfig::MaxCPU", "4")
 	v.SetDefault("DeployConfig::MaxMemory", "8Gi")
 
-	v.SetDefault("KnativeServiceDefaults::TargetConcurrency", "1")
 	v.SetDefault("KnativeServiceDefaults::QueueProxyResourcePercentage", "30")
 	v.SetDefault("KnativeServiceDefaults::UserContainerLimitRequestFactor", "1")
 

--- a/api/turing/config/example.yaml
+++ b/api/turing/config/example.yaml
@@ -119,8 +119,9 @@ KubernetesLabelConfigs:
 # using the appropriate k8s resource specs. The below configs are supported.
 # If left unset, the values shown below will be used as the defaults.
 KnativeServiceDefaults:
-  TargetConcurrency: 1
   QueueProxyResourcePercentage: 30
+  # The CPU / memory limit will be applied as a factor of the requested value
+  UserContainerLimitRequestFactor: 1
 
 # Spark App config for running on Kubernetes
 # This is specific to the environment that you Kubernetes cluster runs on.

--- a/api/turing/config/testdata/config-1.yaml
+++ b/api/turing/config/testdata/config-1.yaml
@@ -15,7 +15,6 @@ DeployConfig:
   MaxCPU: 500m
   MaxMemory: 4000Mi
 KnativeServiceDefaults:
-  TargetConcurrency: 2
   QueueProxyResourcePercentage: 20
   UserContainerLimitRequestFactor: 1.25
 RouterDefaults:

--- a/api/turing/models/autoscaling_policy.go
+++ b/api/turing/models/autoscaling_policy.go
@@ -7,6 +7,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Type to represent the autoscaling metrics supported by Knative.
+// Ref: https://pkg.go.dev/knative.dev/serving/pkg/apis/autoscaling
+//      https://github.com/knative/serving/pull/11668
+
 type AutoscalingMetric string
 
 const (

--- a/infra/cluster-init/init.sh
+++ b/infra/cluster-init/init.sh
@@ -44,6 +44,9 @@ function install_knative {
     kubectl apply \
         -f "https://github.com/knative/serving/releases/download/knative-v${KNATIVE_VERSION:-1.0.1}/serving-core.yaml"
 
+    kubectl apply \
+        -f "https://github.com/knative/serving/releases/download/knative-v${KNATIVE_VERSION:-1.0.1}/serving-hpa.yaml"
+
     local core_apps=("activator" "autoscaler" "controller" "webhook")
     for app in ${core_apps[@]}; do
         kubectl wait -n knative-serving --for=condition=ready pod -l app=${app} --timeout=5m

--- a/infra/docker-compose/dev/docker-compose.yml
+++ b/infra/docker-compose/dev/docker-compose.yml
@@ -4,13 +4,14 @@ volumes:
   # Named volume containing kubeconfig, shared by different containers 
   kube:
 
+
 services:
-  
+
   # Local Docker registry    
   local-registry:
     image: "registry:2.7.1"
     ports:
-    - "5000:5000"
+      - "5000:5000"
 
   # Kubernetes control plane
   server:
@@ -18,43 +19,43 @@ services:
     command: server --disable traefik
     privileged: true
     environment:
-    - K3S_TOKEN=k3stoken
-    - K3S_KUBECONFIG_OUTPUT=/output/kubeconfig.yaml
-    - K3S_KUBECONFIG_MODE=666
+      - K3S_TOKEN=k3stoken
+      - K3S_KUBECONFIG_OUTPUT=/output/kubeconfig.yaml
+      - K3S_KUBECONFIG_MODE=666
     volumes:
-    - "./k3s/registries.yaml:/etc/rancher/k3s/registries.yaml"
-    - "kube:/output"
-    ports: 
-    - "6443:6443"
-    - "80:80"
+      - "./k3s/registries.yaml:/etc/rancher/k3s/registries.yaml"
+      - "kube:/output"
+    ports:
+      - "6443:6443"
+      - "80:80"
 
   # Helper container for copying kubeconfig to host directory
   kubeconfig:
     image: alpine
     restart: on-failure
     volumes:
-    - "kube:/.kube"
-    - "/tmp:/tmp"
+      - "kube:/.kube"
+      - "/tmp:/tmp"
     entrypoint: sh -ec
-    command: 
-    - |
-      cp /.kube/kubeconfig.yaml /tmp/kubeconfig
-      chmod 666 /tmp/kubeconfig
+    command:
+      - |
+        cp /.kube/kubeconfig.yaml /tmp/kubeconfig
+        chmod 666 /tmp/kubeconfig
 
   spark-operator-init:
     image: alpine/helm:3.6.3
     restart: on-failure
     volumes:
-    - "kube:/.kube"
+      - "kube:/.kube"
     entrypoint: sh -ec
-    command: 
-    - |
-      [ -f "/.kube/kubeconfig.yaml" ] || exit 5
-      mkdir -p /.kube
-      cp /.kube/kubeconfig.yaml /.kube/config
-      sed -i 's/127.0.0.1/server/' /.kube/config
-      helm repo add spark-operator https://googlecloudplatform.github.io/spark-on-k8s-operator
-      helm install --insecure-skip-tls-verify spark spark-operator/spark-operator --version 1.1.6 --kubeconfig /.kube/config --wait
+    command:
+      - |
+        [ -f "/.kube/kubeconfig.yaml" ] || exit 5
+        mkdir -p /.kube
+        cp /.kube/kubeconfig.yaml /.kube/config
+        sed -i 's/127.0.0.1/server/' /.kube/config
+        helm repo add spark-operator https://googlecloudplatform.github.io/spark-on-k8s-operator
+        helm install --insecure-skip-tls-verify spark spark-operator/spark-operator --version 1.1.6 --kubeconfig /.kube/config --wait
 
   # Kubernetes worker nodes
   agent:
@@ -63,10 +64,10 @@ services:
       replicas: 3
     privileged: true
     environment:
-    - K3S_URL=https://server:6443
-    - K3S_TOKEN=k3stoken
+      - K3S_URL=https://server:6443
+      - K3S_TOKEN=k3stoken
     volumes:
-    - "./k3s/registries.yaml:/etc/rancher/k3s/registries.yaml"
+      - "./k3s/registries.yaml:/etc/rancher/k3s/registries.yaml"
 
   # Install Istio on Kubernetes 
   istio:
@@ -74,16 +75,16 @@ services:
     restart: on-failure
     user: root:root
     volumes:
-    - "./istio/minimal-operator.yaml:/minimal-operator.yaml"
-    - "kube:/.kube"
+      - "./istio/minimal-operator.yaml:/minimal-operator.yaml"
+      - "kube:/.kube"
     entrypoint: bash -ec
     command:
-    - |
-      cp /.kube/kubeconfig.yaml /.kube/config
-      sed -i 's/127.0.0.1/server/' /.kube/config
-      kubectl cluster-info
-      curl -sL https://istio.io/downloadIstioctl | ISTIO_VERSION=1.12.4 sh -
-      /.istioctl/bin/istioctl install -y -f /minimal-operator.yaml
+      - |
+        cp /.kube/kubeconfig.yaml /.kube/config
+        sed -i 's/127.0.0.1/server/' /.kube/config
+        kubectl cluster-info
+        curl -sL https://istio.io/downloadIstioctl | ISTIO_VERSION=1.12.4 sh -
+        /.istioctl/bin/istioctl install -y -f /minimal-operator.yaml
 
   # Install Knative serving on Kubernetes
   knative:
@@ -91,18 +92,19 @@ services:
     restart: on-failure
     user: root:root
     volumes:
-    - "kube:/.kube"
+      - "kube:/.kube"
     entrypoint: bash -ec
     command:
-    - |
-      cp /.kube/kubeconfig.yaml /.kube/config
-      sed -i 's/127.0.0.1/server/' /.kube/config
-      kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.0.1/serving-crds.yaml
-      kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.0.1/serving-core.yaml
-      kubectl -n knative-serving patch configmap/config-deployment --type merge -p '{"data":{"registriesSkippingTagResolving": "localhost:5000"}}'
-      kubectl -n knative-serving patch configmap/config-domain --type merge -p '{"data":{"127.0.0.1.nip.io":""}}'
-      kubectl apply -f https://github.com/knative-sandbox/net-istio/releases/download/knative-v1.0.0/net-istio.yaml
-  
+      - |
+        cp /.kube/kubeconfig.yaml /.kube/config
+        sed -i 's/127.0.0.1/server/' /.kube/config
+        kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.0.1/serving-crds.yaml
+        kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.0.1/serving-core.yaml
+        kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.0.1/serving-hpa.yaml
+        kubectl -n knative-serving patch configmap/config-deployment --type merge -p '{"data":{"registriesSkippingTagResolving": "localhost:5000"}}'
+        kubectl -n knative-serving patch configmap/config-domain --type merge -p '{"data":{"127.0.0.1.nip.io":""}}'
+        kubectl apply -f https://github.com/knative-sandbox/net-istio/releases/download/knative-v1.0.0/net-istio.yaml
+
   mlp-postgres:
     image: bitnami/postgresql:13.0.0
     environment:
@@ -113,60 +115,60 @@ services:
   mlp-postgres-init:
     image: migrate/migrate:v4.13.0
     restart: on-failure
-    volumes: 
-    - "./mlp/db-migrations:/db-migrations"
+    volumes:
+      - "./mlp/db-migrations:/db-migrations"
     entrypoint: sh -ec
     command:
-    - migrate -path=/db-migrations -database=postgres://mlp:mlp@mlp-postgres:5432/mlp?sslmode=disable up
+      - migrate -path=/db-migrations -database=postgres://mlp:mlp@mlp-postgres:5432/mlp?sslmode=disable up
 
   mlp:
     image: ghcr.io/gojek/mlp:v1.1.0-alpha
     restart: on-failure
     env_file: ./mlp/dev.env
     ports:
-    - "8081:8080"
+      - "8081:8080"
 
   mlp-init:
     image: curlimages/curl:7.73.0
     restart: on-failure
     entrypoint: sh -ec
     command:
-    - |
-      curl \
-        -X POST 'http://mlp:8080/v1/projects' \
-        --header 'Content-Type: application/json' \
-        --data-raw '{"name": "default","team": "default","stream": "default"}'
-      curl 'http://mlp:8080/v1/projects' | grep '"id":1' 
+      - |
+        curl \
+          -X POST 'http://mlp:8080/v1/projects' \
+          --header 'Content-Type: application/json' \
+          --data-raw '{"name": "default","team": "default","stream": "default"}'
+        curl 'http://mlp:8080/v1/projects' | grep '"id":1' 
 
   vault:
     image: vault:1.6.0
     command: server -dev -dev-kv-v1 -dev-root-token-id=root
-    ports: 
-    - "8200:8200"
+    ports:
+      - "8200:8200"
 
   vault-init:
     image: vault:1.6.0
     restart: on-failure
     volumes:
-    - "kube:/.kube"
+      - "kube:/.kube"
     environment:
       VAULT_ADDR: http://vault:8200
       VAULT_TOKEN: root
     entrypoint: sh -ec
-    command: 
-    - |
-      cat /.kube/kubeconfig.yaml | grep -q 'server: https://127.0.0.1:6443'
-      wget -O yq https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64
-      install yq /usr/bin/yq
-      cat <<EOF > /tmp/secret-k3s.json
-      {
-        "master_ip": "$$(cat /.kube/kubeconfig.yaml | yq read - 'clusters[0].cluster.server')",
-        "certs": "$$(cat /.kube/kubeconfig.yaml | yq read - 'clusters[0].cluster.certificate-authority-data' | base64 -d | awk 1 ORS='\\n')",
-        "client_certificate": "$$(cat /.kube/kubeconfig.yaml | yq read - 'users[0].user.client-certificate-data' | base64 -d | awk 1 ORS='\\n')",
-        "client_key": "$$(cat /.kube/kubeconfig.yaml | yq read - 'users[0].user.client-key-data' | base64 -d | awk 1 ORS='\\n')"
-      }
-      EOF
-      vault kv put secret/k3s @/tmp/secret-k3s.json
+    command:
+      - |
+        cat /.kube/kubeconfig.yaml | grep -q 'server: https://127.0.0.1:6443'
+        wget -O yq https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64
+        install yq /usr/bin/yq
+        cat <<EOF > /tmp/secret-k3s.json
+        {
+          "master_ip": "$$(cat /.kube/kubeconfig.yaml | yq read - 'clusters[0].cluster.server')",
+          "certs": "$$(cat /.kube/kubeconfig.yaml | yq read - 'clusters[0].cluster.certificate-authority-data' | base64 -d | awk 1 ORS='\\n')",
+          "client_certificate": "$$(cat /.kube/kubeconfig.yaml | yq read - 'users[0].user.client-certificate-data' | base64 -d | awk 1 ORS='\\n')",
+          "client_key": "$$(cat /.kube/kubeconfig.yaml | yq read - 'users[0].user.client-key-data' | base64 -d | awk 1 ORS='\\n')"
+        }
+        EOF
+        vault kv put secret/k3s @/tmp/secret-k3s.json
 
   merlin-postgres:
     image: bitnami/postgresql:13.0.0
@@ -178,11 +180,11 @@ services:
   merlin:
     image: ghcr.io/gojek/merlin:v0.8.0-alpha
     restart: on-failure
-    volumes: 
-    - "./merlin/deployment-config.yaml:/deployment-config.yaml"
+    volumes:
+      - "./merlin/deployment-config.yaml:/deployment-config.yaml"
     env_file: ./merlin/dev.env
     ports:
-    - "8082:8080"
+      - "8082:8080"
 
   turing-postgres:
     image: bitnami/postgresql:13.0.0
@@ -190,7 +192,7 @@ services:
       POSTGRESQL_DATABASE: turing
       POSTGRESQL_USERNAME: turing
       POSTGRESQL_PASSWORD: turing
-    ports: 
+    ports:
       - "5432:5432"
 
   mockserver:
@@ -198,11 +200,11 @@ services:
     restart: on-failure
     user: root:root
     volumes:
-    - "../../e2e/turing.mockserver.yaml:/mockserver.yaml"
-    - "kube:/.kube"
+      - "../../e2e/turing.mockserver.yaml:/mockserver.yaml"
+      - "kube:/.kube"
     entrypoint: bash -ec
     command:
-    - |
-      cp /.kube/kubeconfig.yaml /.kube/config
-      sed -i 's/127.0.0.1/server/' /.kube/config
-      kubectl apply -f /mockserver.yaml
+      - |
+        cp /.kube/kubeconfig.yaml /.kube/config
+        sed -i 's/127.0.0.1/server/' /.kube/config
+        kubectl apply -f /mockserver.yaml

--- a/sdk/e2e/03_create_router_version_test.py
+++ b/sdk/e2e/03_create_router_version_test.py
@@ -5,7 +5,7 @@ import requests
 import turing
 
 from turing.router.config.experiment_config import ExperimentConfig
-from turing.router.config.autoscaling_policy import AutoscalingPolicy
+from turing.router.config.autoscaling_policy import AutoscalingPolicy, AutoscalingMetric
 from turing.router.config.resource_request import ResourceRequest
 from turing.router.config.enricher import Enricher
 from turing.router.config.common.env_var import EnvVar
@@ -23,7 +23,9 @@ def test_create_router_version():
     new_router_config = router.config
 
     # Set autoscaling policy
-    new_router_config.autoscaling_policy = AutoscalingPolicy(metric="rps", target="100")
+    new_router_config.autoscaling_policy = AutoscalingPolicy(
+        metric=AutoscalingMetric.RPS, target="100"
+    )
 
     # set up the new experiment config
     new_router_config.experiment_config = ExperimentConfig(
@@ -36,7 +38,7 @@ def test_create_router_version():
         resource_request=ResourceRequest(
             min_replica=1, max_replica=1, cpu_request="10", memory_request="1Gi"
         ),
-        autoscaling_policy=AutoscalingPolicy(metric="rps", target="100"),
+        autoscaling_policy=AutoscalingPolicy(metric=AutoscalingMetric.CPU, target="80"),
         endpoint="anything",
         timeout="2s",
         port=80,
@@ -49,7 +51,7 @@ def test_create_router_version():
         resource_request=ResourceRequest(
             min_replica=2, max_replica=2, cpu_request="200m", memory_request="256Mi"
         ),
-        autoscaling_policy=AutoscalingPolicy(metric="rps", target="100"),
+        autoscaling_policy=AutoscalingPolicy(metric=AutoscalingMetric.CPU, target="80"),
         endpoint="anything",
         timeout="3s",
         port=80,

--- a/sdk/e2e/03_create_router_version_test.py
+++ b/sdk/e2e/03_create_router_version_test.py
@@ -51,7 +51,9 @@ def test_create_router_version():
         resource_request=ResourceRequest(
             min_replica=2, max_replica=2, cpu_request="200m", memory_request="256Mi"
         ),
-        autoscaling_policy=AutoscalingPolicy(metric=AutoscalingMetric.CPU, target="80"),
+        autoscaling_policy=AutoscalingPolicy(
+            metric=AutoscalingMetric.MEMORY, target="220"
+        ),
         endpoint="anything",
         timeout="3s",
         port=80,

--- a/ui/src/router/components/form/components/autoscaling_policy/AutoscalingPolicyPanel.js
+++ b/ui/src/router/components/form/components/autoscaling_policy/AutoscalingPolicyPanel.js
@@ -89,6 +89,7 @@ export const AutoscalingPolicyPanel = ({
               name="memory"
               min={1}
               step={1}
+              append={selectedMetric.unit}
             />
           </EuiFormRow>
         </DescribedFormGroup>

--- a/ui/src/router/components/form/components/autoscaling_policy/AutoscalingPolicyPanelFlyout.js
+++ b/ui/src/router/components/form/components/autoscaling_policy/AutoscalingPolicyPanelFlyout.js
@@ -52,7 +52,7 @@ export const AutoscalingPolicyPanelFlyout = ({ onClose }) => {
               <b>CPU / Memory:</b> These can be chosen according to whether the process is CPU bound
               or memory bound. With this, scale to 0 is not supported. CPU is specified in
               terms of the % utilization of the requested value (Eg: 75 indicates 75%),
-              while memory is specified in units of MiB (Eg: 100 indicates 100MiB).
+              while memory is specified in units of Mi (Eg: 100 indicates 100Mi).
             </li>
           </ul>
         </EuiText>

--- a/ui/src/router/components/form/components/autoscaling_policy/typeOptions.js
+++ b/ui/src/router/components/form/components/autoscaling_policy/typeOptions.js
@@ -15,12 +15,14 @@ export const autoscalingPolicyOptions = [
     inputDisplay: "CPU",
     description: `Traditional CPU-based autoscaling.
                       When the specified target (%) is reached, a new replica will be added.`,
+    unit: "%",
   },
   {
     value: "memory",
     inputDisplay: "Memory",
     description: `Traditional memory-based autoscaling.
                       When the specified target (in Mi) is reached, a new replica will be added.`,
+    unit: "Mi",
   },
 ];
 

--- a/ui/src/router/components/form/components/autoscaling_policy/typeOptions.js
+++ b/ui/src/router/components/form/components/autoscaling_policy/typeOptions.js
@@ -14,7 +14,7 @@ export const autoscalingPolicyOptions = [
     value: "cpu",
     inputDisplay: "CPU",
     description: `Traditional CPU-based autoscaling.
-                      When the specified target (%) is reached, a new replica will be added.`,
+                      When the specified target (% request) is reached, a new replica will be added.`,
     unit: "%",
   },
   {

--- a/ui/src/router/components/form/components/autoscaling_policy/typeOptions.js
+++ b/ui/src/router/components/form/components/autoscaling_policy/typeOptions.js
@@ -20,7 +20,7 @@ export const autoscalingPolicyOptions = [
     value: "memory",
     inputDisplay: "Memory",
     description: `Traditional memory-based autoscaling.
-                      When the specified target (in MiB) is reached, a new replica will be added.`,
+                      When the specified target (in Mi) is reached, a new replica will be added.`,
   },
 ];
 


### PR DESCRIPTION
This PR is a follow up from the previous ones, to expose autoscaling configurations to the Turing users, and it updates the infra set up to include the HPA along with a few small fixes. Previous PRs:
* https://github.com/caraml-dev/turing/pull/234
* https://github.com/caraml-dev/turing/pull/236

### Modifications
* `.github/workflows/cluster-init.yaml` - Increase the versions of Knative / Knative Istio, to use the same default value used by the cluster init script.
* `api/turing/config/config.go` - Clean up outdated config (also from other test / example files)
* `infra/cluster-init/init.sh`, `infra/docker-compose/dev/docker-compose.yml` - Install the optional [Knative serving extension for HPA](https://knative.dev/docs/install/yaml-install/serving/install-serving-with-yaml/#install-optional-serving-extensions)
<img width="805" alt="autoscale" src="https://user-images.githubusercontent.com/23465343/190035925-90c911ec-d20a-4a27-a870-8611e8357565.png">

* `ui/src/router/components/form/components/autoscaling_policy/AutoscalingPolicyPanel.js` - Display autoscaling metric unit (% for CPU, Mi for memory and nothing for the rest) for clarity

<img width="1299" alt="Screenshot 2022-09-14 at 8 39 39 AM" src="https://user-images.githubusercontent.com/23465343/190035896-b5507555-5687-4735-ab36-081d1a89a775.png">

* Update e2e tests to exercise CPU / Memory based autoscaling metrics