### PR TITLE
Bugfix: Handle non-string ensembler dependencies in conda_env

### DIFF
--- a/sdk/tests/ensembler_test.py
+++ b/sdk/tests/ensembler_test.py
@@ -100,7 +100,10 @@ def test_create_ensembler(
     actual = turing.PyFuncEnsembler.create(
         name=pyfunc_ensembler.name,
         ensembler_instance=tests.MyTestEnsembler(0.01),
-        conda_env={"channels": ["defaults"], "dependencies": ["python=3.7.0"]},
+        conda_env={
+            "channels": ["defaults"],
+            "dependencies": ["python=3.7.0", {"pip": ["test-lib==0.0.1"]}],
+        },
     )
 
     assert actual == turing.PyFuncEnsembler.from_open_api(pyfunc_ensembler)
@@ -141,7 +144,10 @@ def test_update_ensembler(
     actual.update(
         name=pyfunc_ensembler.name,
         ensembler_instance=tests.MyTestEnsembler(0.06),
-        conda_env={"channels": ["defaults"], "dependencies": ["python>=3.8.0"]},
+        conda_env={
+            "channels": ["defaults"],
+            "dependencies": ["python>=3.8.0", {"pip": ["test-lib==0.0.1"]}],
+        },
         code_dir=[
             os.path.join(
                 os.path.dirname(os.path.realpath(__file__)), "..", "samples/quickstart"

--- a/sdk/turing/ensembler.py
+++ b/sdk/turing/ensembler.py
@@ -413,7 +413,9 @@ def _process_conda_env(
         # conda dependencies whose spec differs slightly from Python's setuptools.
         # We could install the complete conda library but this is too bulky if the goal is
         # to just carry out this matching.
-        return spec == name or re.match(name + r"[><=\s]+", spec) is not None
+        return isinstance(spec, str) and (
+            spec == name or re.match(name + r"[><=\s]+", spec) is not None
+        )
 
     if isinstance(conda_env, str):
         with open(conda_env, "r") as f:


### PR DESCRIPTION
When logging an ensembler, we create / replace the python version conda dependency such that it matches the minor version. Eg: `python=3.7.*`

The comparison function that matched the python dependency from the conda_env dependencies treated each item as a string whereas they could also be objects ([example](https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#mlflow.pyfunc.log_model)).

This resulted in an error when attempting to create ensemblers with explicit `pip` dependencies. This PR addresses this bug and updates the unit test cases to cover complex dependencies.