### PR TITLE
Bugfix: Migration for autoscaling configs when using pyfunc ensemblers

### DIFF
--- a/api/db-migrations/000014_autoscaling_policy.down.sql
+++ b/api/db-migrations/000014_autoscaling_policy.down.sql
@@ -1,4 +1,5 @@
 ALTER TABLE enrichers DROP COLUMN autoscaling_policy;
 ALTER TABLE router_versions DROP COLUMN autoscaling_policy;
-UPDATE ensembler_configs set docker_config = docker_config - 'autoscaling_policy' WHERE type='docker';
+UPDATE ensembler_configs set docker_config = docker_config - 'autoscaling_policy'
+    WHERE (type='docker' OR type='pyfunc') AND docker_config IS NOT NULL;
 UPDATE ensembler_configs set pyfunc_config = pyfunc_config - 'autoscaling_policy' WHERE type='pyfunc';

--- a/api/db-migrations/000014_autoscaling_policy.up.sql
+++ b/api/db-migrations/000014_autoscaling_policy.up.sql
@@ -7,6 +7,6 @@ ALTER TABLE router_versions ADD autoscaling_policy jsonb NOT NULL DEFAULT '{"met
 ALTER TABLE router_versions ALTER COLUMN autoscaling_policy DROP DEFAULT;
 -- ensemblers
 UPDATE ensembler_configs set docker_config = docker_config || jsonb '{"autoscaling_policy": {"metric": "concurrency", "target": "1"}}'
-    WHERE type='docker';
+    WHERE (type='docker' OR type='pyfunc') AND docker_config IS NOT NULL;
 UPDATE ensembler_configs set pyfunc_config = pyfunc_config || jsonb '{"autoscaling_policy": {"metric": "concurrency", "target": "1"}}'
     WHERE type='pyfunc';


### PR DESCRIPTION
Follow up from the previous related bugfix PR: https://github.com/caraml-dev/turing/pull/243

As the docker configs are also present in Pyfunc ensembler configs, the migration scripts need to account for them as well and update the autoscaling policy if the `docker_config` is not NULL (which can happen if the image was never successfully built).