### PR TITLE
Accept HPA memory target as %

### DIFF
--- a/api/turing/cluster/controller.go
+++ b/api/turing/cluster/controller.go
@@ -257,7 +257,10 @@ func (c *controller) DeployKnativeService(ctx context.Context, svcConf *KnativeS
 	var err error
 
 	// Build the deployment specs
-	desiredSvc := svcConf.BuildKnativeServiceConfig()
+	desiredSvc, err := svcConf.BuildKnativeServiceConfig()
+	if err != nil {
+		return err
+	}
 
 	// Init knative ServicesGetter
 	services := c.knServingClient.Services(svcConf.Namespace)

--- a/api/turing/cluster/controller_test.go
+++ b/api/turing/cluster/controller_test.go
@@ -160,8 +160,8 @@ func TestDeployKnativeService(t *testing.T) {
 			monkey.PatchInstanceMethod(
 				reflect.TypeOf(svcConf),
 				"BuildKnativeServiceConfig",
-				func(*KnativeService) *knservingv1.Service {
-					return testKnSvc
+				func(*KnativeService) (*knservingv1.Service, error) {
+					return testKnSvc, nil
 				})
 			monkey.Patch(knServiceSemanticEquals,
 				func(*knservingv1.Service, *knservingv1.Service) bool {

--- a/api/turing/cluster/models.go
+++ b/api/turing/cluster/models.go
@@ -67,8 +67,8 @@ func (cfg *BaseService) buildResourceReqs(userContainerLimitRequestFactor float6
 
 	// Set resource limits to request * userContainerLimitRequestFactor
 	limits := map[corev1.ResourceName]resource.Quantity{
-		corev1.ResourceCPU:    computeResource(cfg.CPURequests, userContainerLimitRequestFactor),
-		corev1.ResourceMemory: computeResource(cfg.MemoryRequests, userContainerLimitRequestFactor),
+		corev1.ResourceCPU:    ComputeResource(cfg.CPURequests, userContainerLimitRequestFactor),
+		corev1.ResourceMemory: ComputeResource(cfg.MemoryRequests, userContainerLimitRequestFactor),
 	}
 
 	return corev1.ResourceRequirements{
@@ -125,7 +125,7 @@ type ConfigMap struct {
 
 // Ref:
 // https://github.com/knative/serving/blob/release-0.14/pkg/reconciler/revision/resources/queue.go#L115
-func computeResource(resourceQuantity resource.Quantity, fraction float64) resource.Quantity {
+func ComputeResource(resourceQuantity resource.Quantity, fraction float64) resource.Quantity {
 	scaledValue := resourceQuantity.Value()
 	scaledMilliValue := int64(math.MaxInt64 - 1)
 	if scaledValue < (math.MaxInt64 / 1000) {

--- a/api/turing/models/autoscaling_policy.go
+++ b/api/turing/models/autoscaling_policy.go
@@ -22,7 +22,10 @@ const (
 
 type AutoscalingPolicy struct {
 	Metric AutoscalingMetric `json:"metric" validate:"required,oneof=concurrency rps cpu memory"`
-	Target string            `json:"target" validate:"required,number"`
+	// Target is the target value of the metric that should be reached to add a new replica.
+	// It is expected that the autoscaling target is an absolute value for concurrency / rps
+	// while it is a % value (of the requested value) for cpu / memory.
+	Target string `json:"target" validate:"required,number"`
 }
 
 func (a AutoscalingPolicy) Value() (driver.Value, error) {

--- a/ui/src/router/components/form/components/autoscaling_policy/AutoscalingPolicyPanelFlyout.js
+++ b/ui/src/router/components/form/components/autoscaling_policy/AutoscalingPolicyPanelFlyout.js
@@ -50,9 +50,8 @@ export const AutoscalingPolicyPanelFlyout = ({ onClose }) => {
             </li>
             <li>
               <b>CPU / Memory:</b> These can be chosen according to whether the process is CPU bound
-              or memory bound. With this, scale to 0 is not supported. CPU is specified in
-              terms of the % utilization of the requested value (Eg: 75 indicates 75%),
-              while memory is specified in units of Mi (Eg: 100 indicates 100Mi).
+              or memory bound. With this, scale to 0 is not supported. CPU and Memory are specified in
+              terms of the % utilization of the requested value (Eg: 75 indicates 75%).
             </li>
           </ul>
         </EuiText>

--- a/ui/src/router/components/form/components/autoscaling_policy/typeOptions.js
+++ b/ui/src/router/components/form/components/autoscaling_policy/typeOptions.js
@@ -21,8 +21,8 @@ export const autoscalingPolicyOptions = [
     value: "memory",
     inputDisplay: "Memory",
     description: `Traditional memory-based autoscaling.
-                      When the specified target (in Mi) is reached, a new replica will be added.`,
-    unit: "Mi",
+                      When the specified target (% request) is reached, a new replica will be added.`,
+    unit: "%",
   },
 ];
 


### PR DESCRIPTION
When the autoscaling metric is set to "memory", Knative expects the target to be supplied in the unit of `Mi` ([ref](https://pkg.go.dev/knative.dev/serving/pkg/apis/autoscaling)). It is common for users to configure the HPA using resource utilization % instead and this is the unit used for the "cpu" metric by Knative as well. Moreover, if `Mi` is used as the unit, the users may need to update the autoscaling target value every time the memory requested is altered.

Thus, this PR changes the handling of the target value set for the memory metric so that the saved config will be treated as `%` and subsequently applied as `Mi`. This will make the configuration consistent for the end users.

### Main changes
* `api/turing/cluster/knative_service.go` - Add method `getAutoscalingTarget` for manipulating the target, if "memory" is used.
* `api/turing/cluster/knative_service_test.go` - Add unit tests for the `getAutoscalingTarget` method, to test the conversions
* Update the documentation in the UI, for the memory unit

CC: @ariefrahmansyah 