### PR TITLE
Bugfix: Fix UI bugs with standard ensemblers and rules update

### DIFF
--- a/ui/src/router/components/form/components/ensembler_config/RouteSelectionPanel.js
+++ b/ui/src/router/components/form/components/ensembler_config/RouteSelectionPanel.js
@@ -69,7 +69,7 @@ export const RouteSelectionPanel = ({
             id={e.id}
             endpoint={e.endpoint}
             isDisabled={isDisabled}
-            disabledOptionTooltip="Route with traffic rules cannot be selected"
+            disabledOptionTooltip="Route should be a part of every traffic rule including the default rule"
           />
         ),
         disabled: isDisabled,

--- a/ui/src/router/components/form/components/router_config/RulesPanel.js
+++ b/ui/src/router/components/form/components/router_config/RulesPanel.js
@@ -114,6 +114,8 @@ export const RulesPanel = ({ default_traffic_rule, rules, routes, onChangeHandle
             )}
           </EuiDraggable>
         ))}
+        </EuiDroppable>
+        </EuiDragDropContext>
         <EuiFlexItem>
           {routes.length < 2 ? (
             <EuiToolTip content="You should have more than one route in order to be able to define traffic rules">
@@ -123,8 +125,6 @@ export const RulesPanel = ({ default_traffic_rule, rules, routes, onChangeHandle
             addRuleButton
           )}
         </EuiFlexItem>
-        </EuiDroppable>
-        </EuiDragDropContext>
       </EuiFlexGroup>
 
       {isFlyoutVisible && (

--- a/ui/src/router/components/form/validation/schema.js
+++ b/ui/src/router/components/form/validation/schema.js
@@ -248,7 +248,8 @@ const mappingSchema = yup.object().shape({
 });
 
 const standardEnsemblerConfigSchema = yup.object().shape({
-  experiment_mappings: yup.array(mappingSchema),
+  route_name_path: yup.string().nullable(),
+  experiment_mappings: yup.array(mappingSchema).nullable(),
   fallback_response_route_id: validRouteSchema,
 });
 

--- a/ui/src/services/ensembler/Ensembler.js
+++ b/ui/src/services/ensembler/Ensembler.js
@@ -32,6 +32,9 @@ export class Ensembler {
         if (this.standard_config.experiment_mappings?.length === 0) {
           delete this.standard_config.experiment_mappings;
         }
+        if (this.standard_config.route_name_path === "") {
+          delete this.standard_config.route_name_path;
+        }
         return { type: this.type, standard_config: this.standard_config };
       case "pyfunc":
         return { type: this.type, pyfunc_config: this.pyfunc_config };

--- a/ui/src/services/ensembler/Ensembler.js
+++ b/ui/src/services/ensembler/Ensembler.js
@@ -29,6 +29,9 @@ export class Ensembler {
       case "docker":
         return { type: this.type, docker_config: this.docker_config };
       case "standard":
+        if (this.standard_config.experiment_mappings?.length === 0) {
+          delete this.standard_config.experiment_mappings;
+        }
         return { type: this.type, standard_config: this.standard_config };
       case "pyfunc":
         return { type: this.type, pyfunc_config: this.pyfunc_config };


### PR DESCRIPTION
## Context
In the run up to the release of a new Turing version, this PR aims to fix several observed bugs in the UI:


- the tooltip from selecting an invalid fallback response route displaying "Route with traffic rules cannot be selected"
- the validation schema for standard ensemblers with custom experiment engines not performing validation correctly during a router update when the `experiment_mappings` field is `undefined` (as saved within the db)
- the '+ Add Rule' button in the create/edit router form being part of an `EuiDroppable` area

https://user-images.githubusercontent.com/36802364/192656894-883ff801-1d03-45e2-8a3e-d43210ac9606.mov
