### PR TITLE
Bugfix: Fix diff page to display router rules

### DIFF
--- a/ui/src/router/components/form/validation/schema.js
+++ b/ui/src/router/components/form/validation/schema.js
@@ -247,11 +247,22 @@ const mappingSchema = yup.object().shape({
   route: yup.string().required("Treatment needs to be mapped back to a route"),
 });
 
-const standardEnsemblerConfigSchema = yup.object().shape({
-  route_name_path: yup.string().nullable(),
-  experiment_mappings: yup.array(mappingSchema).nullable(),
-  fallback_response_route_id: validRouteSchema,
-});
+const standardEnsemblerConfigSchema = yup
+  .object()
+  .shape({
+    route_name_path: yup.string().nullable(),
+    experiment_mappings: yup.array(mappingSchema).nullable(),
+    fallback_response_route_id: validRouteSchema,
+  })
+  .test(
+    "is-route-name-path-or-experiment-mappings-set",
+    "only one of route_name_path or experiment_mappings must be set",
+    (standardEnsembler) => {
+      const isRouteNamePathEmpty = !standardEnsembler.route_name_path;
+      const isExperimentMappingsEmpty = !standardEnsembler.experiment_mappings || standardEnsembler.experiment_mappings.length === 0;
+      return !((isRouteNamePathEmpty && isExperimentMappingsEmpty) || (!isRouteNamePathEmpty && !isExperimentMappingsEmpty));
+    }
+  );
 
 const bigQueryConfigSchema = yup.object().shape({
   table: yup

--- a/ui/src/services/version/RouterVersion.js
+++ b/ui/src/services/version/RouterVersion.js
@@ -79,11 +79,18 @@ export class RouterVersion {
       router: {
         image: this.image,
         timeout: this.timeout,
+        default_traffic_rule: {routes: this.default_traffic_rule.routes.join()},
         routes: this.routes.map((route) => ({
           id: route.id,
           endpoint: route.endpoint,
           timeout: route.timeout,
           is_default: route.id === this.default_route_id,
+        })),
+        rules: this.rules.map((rule) => ({
+          conditions: rule.conditions.map((condition) => ({
+            [condition.field_source]: `${condition.field} ${condition.operator.toUpperCase()} [${condition.values.join()}]`
+          })),
+          routes: rule.routes.join(),
         })),
         resource_request: this.resource_request,
         autoscaling_policy: {


### PR DESCRIPTION
## Context
Previously the router diff page does not display the router rules even when changes to them are made. This PR thus introduces a tiny fix that allows the rules configured to be displayed on the diff page.

An additional fix to address https://github.com/caraml-dev/turing/pull/251#discussion_r981861582 has also been made to ensure that only the `route_name_path` or `experiment_mappings` field must be set within the `standard_ensembler` map.