### PR TITLE
Fix v1.7.0-rc1 bugs

### DIFF
--- a/ui/src/services/version/RouterVersion.js
+++ b/ui/src/services/version/RouterVersion.js
@@ -163,14 +163,14 @@ export class RouterVersion {
     };
 
     if (this.default_traffic_rule) {
-      pretty.router["default_traffic_rule"] = {routes: this.default_traffic_rule.routes.join()};
+      pretty.router["default_traffic_rule"] = {routes: this.default_traffic_rule.routes.join(", ")};
     }
     if (this.rules?.length > 0) {
       pretty.router["rules"] = this.rules.map((rule) => ({
         conditions: rule.conditions.map((condition) => ({
-          [condition.field_source]: `${condition.field} ${condition.operator.toUpperCase()} [${condition.values.join()}]`
+          [condition.field_source]: `${condition.field} ${condition.operator.toUpperCase()} [${condition.values.join(", ")}]`
         })),
-        routes: rule.routes.join(),
+        routes: rule.routes.join(", "),
       }))
     }
 

--- a/ui/src/services/version/RouterVersion.js
+++ b/ui/src/services/version/RouterVersion.js
@@ -79,18 +79,11 @@ export class RouterVersion {
       router: {
         image: this.image,
         timeout: this.timeout,
-        default_traffic_rule: {routes: this.default_traffic_rule.routes.join()},
         routes: this.routes.map((route) => ({
           id: route.id,
           endpoint: route.endpoint,
           timeout: route.timeout,
           is_default: route.id === this.default_route_id,
-        })),
-        rules: this.rules.map((rule) => ({
-          conditions: rule.conditions.map((condition) => ({
-            [condition.field_source]: `${condition.field} ${condition.operator.toUpperCase()} [${condition.values.join()}]`
-          })),
-          routes: rule.routes.join(),
         })),
         resource_request: this.resource_request,
         autoscaling_policy: {
@@ -168,6 +161,19 @@ export class RouterVersion {
             : undefined),
       },
     };
+
+    if (this.default_traffic_rule) {
+      pretty.router["default_traffic_rule"] = {routes: this.default_traffic_rule.routes.join()};
+    }
+    if (this.rules?.length > 0) {
+      pretty.router["rules"] = this.rules.map((rule) => ({
+        conditions: rule.conditions.map((condition) => ({
+          [condition.field_source]: `${condition.field} ${condition.operator.toUpperCase()} [${condition.values.join()}]`
+        })),
+        routes: rule.routes.join(),
+      }))
+    }
+
     return yaml.dump(pretty, { sortKeys: true });
   }
 }


### PR DESCRIPTION
## Context
With `v1.7.0-rv1` released, several bugs where observed and this PR serves to introduces bug fixes to address them:

- Router version diff page crashing whenever traffic rules are absent 
   - Traffic rules (including the default rule) are only added to the pretty print only when they are present