### PR TITLE
Fix Autoscaling config info in the Pyfunc ensembler view

### DIFF
--- a/ui/src/router/components/configuration/components/pyfunc_config_section/PyFuncConfigViewGroup.js
+++ b/ui/src/router/components/configuration/components/pyfunc_config_section/PyFuncConfigViewGroup.js
@@ -38,7 +38,7 @@ export const PyFuncConfigViewGroup = ({
       <EuiFlexItem grow={1} className="euiFlexItem--smallPanel">
         <ResourcesConfigTable
           componentName="Ensembler"
-          autoscalingPolicy={dockerConfig.autoscaling_policy}
+          autoscalingPolicy={pyfuncConfig.autoscaling_policy}
           resourceRequest={pyfuncConfig.resource_request}
         />
       </EuiFlexItem>


### PR DESCRIPTION
Incorrect typo of `dockerConfig` which should have been `pyfuncConfig`.