### PR TITLE
Bugfix: Fix RFC-1123 hostname string validation for ensembler names

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/caraml-dev/turing/engines/router v0.0.0
 	github.com/getkin/kin-openapi v0.76.0
 	github.com/ghodss/yaml v1.0.0
-	github.com/go-playground/validator/v10 v10.9.0
+	github.com/go-playground/validator/v10 v10.11.1
 	github.com/gojek/fiber v0.0.0-20201008181849-4f0f8284dc84
 	github.com/gojek/merlin v0.0.0
 	github.com/gojek/mlp v1.4.7
@@ -151,7 +151,7 @@ require (
 	go.mongodb.org/mongo-driver v1.1.2 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
+	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3 // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -674,8 +674,8 @@ github.com/go-playground/universal-translator v0.18.0/go.mod h1:UvRDBj+xPUEGrFYl
 github.com/go-playground/validator v9.30.0+incompatible/go.mod h1:yrEkQXlcI+PugkyDjY2bRrL/UBU4f3rvrgkN3V8JEig=
 github.com/go-playground/validator v9.31.0+incompatible h1:UA72EPEogEnq76ehGdEDp4Mit+3FDh548oRqwVgNsHA=
 github.com/go-playground/validator v9.31.0+incompatible/go.mod h1:yrEkQXlcI+PugkyDjY2bRrL/UBU4f3rvrgkN3V8JEig=
-github.com/go-playground/validator/v10 v10.9.0 h1:NgTtmN58D0m8+UuxtYmGztBJB7VnPgjj221I1QHci2A=
-github.com/go-playground/validator/v10 v10.9.0/go.mod h1:74x4gJWsvQexRdW8Pn3dXSGrTK4nAUsbPlLADvpJkos=
+github.com/go-playground/validator/v10 v10.11.1 h1:prmOlTVv+YjZjmRmNSF3VmspqJIxJWXmqUsHwfTRRkQ=
+github.com/go-playground/validator/v10 v10.11.1/go.mod h1:i+3WkQ1FvaUjjxh1kSvIA4dMGDBiPU55YFDl0WbKdWU=
 github.com/go-redis/redis v6.14.2+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/go-redis/redis v6.15.8+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/go-sql-driver/mysql v0.0.0-20180308100310-1a676ac6e4dc/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
@@ -1826,10 +1826,10 @@ golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWP
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
-golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 h1:7I4JAnoQBe7ZtJcBaYHi5UtiO8tQHbUSXxL+pnGRANg=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3 h1:0es+/5331RGQPcXlMfP+WrnIIS6dNnNRe0WB02W0F4M=
+golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1949,6 +1949,7 @@ golang.org/x/net v0.0.0-20210510120150-4163338589ed/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211209124913-491a49abca63/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b h1:PxfKdU9lEEDYjdIzOtC4qFWgkU2rGHdKlKowJSMN9h0=

--- a/api/turing/imagebuilder/ensembler.go
+++ b/api/turing/imagebuilder/ensembler.go
@@ -33,7 +33,7 @@ func (n *ensemblerJobNameGenerator) generateBuilderName(
 	versionID string,
 ) string {
 	// Creates a unique resource name with partial versioning (part of the versionID hash) as max char count is limited
-	// by k8s pod name length (63)
+	// by k8s job name length (63)
 	partialVersionID := getPartialVersionID(versionID, 5)
 	return fmt.Sprintf("batch-%s-%s-%d-%s", projectName, modelName, modelID, partialVersionID)
 }


### PR DESCRIPTION
## TL;DR
Problem: Users create ensembler names with underscores -> Invalid Kaniko job names -> Invalid K8s jobs -> Router deployments fail

Solution: Add additional API checks to block usage of underscores -> Discovery of bug in existing `go-validator` validation tag to validate ensembler names -> Update `go-validator` -> Done

## Context
Pyfunc ensemblers are built as a web service and containerised into a single image upon being deployed as part of a router deployment. This image building process takes place in Kaniko builders run as _jobs_ on a Kubernetes cluster. The Turing API names these jobs automatically, in a way which [incorporates](https://github.com/caraml-dev/turing/blob/main/api/turing/imagebuilder/imagebuilder.go#L133) the user-registered name of the ensemblers to be built:

```go
kanikoJobName := ib.nameGenerator.generateBuilderName(
	request.ProjectName,
	request.ResourceName,  // this refers to the name of the ensembler
	request.ResourceID,
	request.VersionID,
)
```
where the method `generateBuilderName` is given by:

```go
func (n *ensemblerJobNameGenerator) generateBuilderName(
	projectName string,
	modelName string,
	modelID models.ID,
	versionID string,
) string {
	partialVersionID := getPartialVersionID(versionID, 5)
	return fmt.Sprintf("batch-%s-%s-%d-%s", projectName, modelName, modelID, partialVersionID)
}
```
Errors thus occur when users define their ensembler names with underscores (`_`) , because this causes the job names generated to similarly contain them, rendering the job names of the Kaniko builders [**invalid**](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names) when run in a Kubernetes cluster, since Kubernetes requires the job names to fulfil standards defined in RFC 1123, i.e.

- contain only lowercase alphanumeric characters or '-'
- start with an alphanumeric character
- end with an alphanumeric character

Router deployments using ensemblers that have underscores in their names thus fail immediately since the image building jobs get rejected instantly.

## Fix
The original intention of the fix was to introduce additional API checks to validate the ensembler names submitted by users and then return appropriate errors to prevent the above mentioned errors from occurring. 

However, it was found that the existing `GenericEnsembler` struct that gets created when handling ensembler creation/update API calls already contains the necessary `go-playground` validator `hostname_rfc1123` [validation](https://pkg.go.dev/github.com/go-playground/validator/v10#hdr-Hostname_RFC_1123) for those RFC 1123 standards on the `Name` field:

```go
type GenericEnsembler struct {
	Model

	ProjectID ID `json:"project_id" gorm:"column:project_id"`

	Type EnsemblerType `json:"type" gorm:"column:type" validate:"required,oneof=pyfunc"`

	Name string `json:"name" gorm:"column:name" validate:"required,hostname_rfc1123,lte=20,gte=3"`
}
```

Clearly, there was an apparent bug with the `hostname_rfc1123` validation tag that led to the observed bug that this PR is trying to address. Upon further investigation, it was found that the existing version (`v10.9.0`) of the `go-playground` validator used by the Turing API does not contain the necessary bug fix for the `hostname_rfc1123` validation tag. 

Fortunately, all that's needed is to update its version to `v10.11.0`, which [includes](https://github.com/go-playground/validator/releases/tag/v10.11.0) the required [bug fix](https://github.com/go-playground/validator/pull/912) (PR #912). And since `v10.11.1` is the newest release with an additional bug fix, why not just update the dependency to the latest version? 🙃

## Miscellaneous
This PR also makes a tiny modification to an incorrect docstring mentioning Kaniko jobs as 'pods'.