### PR TITLE
Bugfix: Fix UI crashes when changing between experiment engines

### DIFF
--- a/infra/cluster-init/init.sh
+++ b/infra/cluster-init/init.sh
@@ -47,13 +47,13 @@ function install_knative {
     kubectl apply \
         -f "https://github.com/knative/serving/releases/download/knative-v${KNATIVE_VERSION:-1.0.1}/serving-hpa.yaml"
 
-    kubectl apply \
-        -f knative-configmaps/config-features.yaml
-
     local core_apps=("activator" "autoscaler" "controller" "webhook")
     for app in ${core_apps[@]}; do
         kubectl wait -n knative-serving --for=condition=ready pod -l app=${app} --timeout=5m
     done
+
+    kubectl apply \
+        -f knative-configmaps/config-features.yaml
 
     kubectl apply \
         -f "https://github.com/knative-sandbox/net-istio/releases/download/knative-v${KNATIVE_ISTIO_VERSION:-1.0.0}/net-istio.yaml"

--- a/ui/src/router/components/form/components/ensembler_config/standard_ensembler/StandardEnsemblerFormGroup.js
+++ b/ui/src/router/components/form/components/ensembler_config/standard_ensembler/StandardEnsemblerFormGroup.js
@@ -100,7 +100,7 @@ export const StandardEnsemblerFormGroup = ({
         {engineProps?.type === "standard" ? (
           <EuiFlexItem>
             <StandardEnsemblerPanel
-              experiments={experimentEngine.config.experiments}
+              experiments={experimentEngine.config?.experiments || []}
               mappings={standardConfig.experiment_mappings}
               routeOptions={routeOptions}
               onChangeHandler={onChange("experiment_mappings")}

--- a/ui/src/router/components/form/steps/EnsemblerStep.js
+++ b/ui/src/router/components/form/steps/EnsemblerStep.js
@@ -69,7 +69,7 @@ export const EnsemblerStep = ({ projectId }) => {
         />
       )}
 
-      {experiment_engine.type !== "nop" && ensembler.type === "standard" && (
+      {ensembler.type === "standard" && (
         <StandardEnsemblerFormGroup
           projectId={projectId}
           experimentEngine={experiment_engine}

--- a/ui/src/router/components/form/steps/EnsemblerStep.js
+++ b/ui/src/router/components/form/steps/EnsemblerStep.js
@@ -69,7 +69,7 @@ export const EnsemblerStep = ({ projectId }) => {
         />
       )}
 
-      {ensembler.type === "standard" && (
+      {experiment_engine.type !== "nop" && ensembler.type === "standard" && (
         <StandardEnsemblerFormGroup
           projectId={projectId}
           experimentEngine={experiment_engine}

--- a/ui/src/router/components/form/steps/ExperimentStep.js
+++ b/ui/src/router/components/form/steps/ExperimentStep.js
@@ -27,6 +27,10 @@ export const ExperimentStep = ({ projectId }) => {
     onChange("config.experiment_engine")({ type: newType });
     // Reset the standard ensembler config if the engine type is changed
     if (ensemblerType === "standard") {
+      // Standard Ensemblers are not available when no experiment engine is configured
+      if (newType === "nop") {
+        onChange("config.ensembler.type")("nop");
+      }
       onChange("config.ensembler.standard_config.experiment_mappings")([]);
       onChange("config.ensembler.standard_config.route_name_path")("");
     }

--- a/ui/src/router/components/form/steps/ExperimentStep.js
+++ b/ui/src/router/components/form/steps/ExperimentStep.js
@@ -25,6 +25,11 @@ export const ExperimentStep = ({ projectId }) => {
   const onChangeEngineType = (newType) => {
     // Reset the experiment config if the engine type changed
     onChange("config.experiment_engine")({ type: newType });
+    // Reset the standard ensembler config if the engine type is changed
+    if (ensemblerType === "standard") {
+      onChange("config.ensembler.standard_config.experiment_mappings")([]);
+      onChange("config.ensembler.standard_config.route_name_path")("");
+    }
   };
 
   const { experimentEngines, getEngineProperties } = useContext(


### PR DESCRIPTION
## Context
This PR addresses 2 main bugs that have been found with the UI:

1. Currently when editing a router, if a user changes from a custom experiment engine to a standard engine, both of which use Standard Ensemblers, the UI crashes because it supposedly is unable to locate the list of experiments configured for the standard experiment engine.
![Screenshot 2022-10-17 at 3 30 05 PM](https://user-images.githubusercontent.com/36802364/196115283-272782cb-41d2-436d-88a7-2273aaa84b85.png)
This in reality, happens only momentarily when an [effect](https://github.com/caraml-dev/turing/blob/345e9b001adaa7da95b0f99757ce15672711c1f0/ui/src/router/components/form/steps/ExperimentStep.js#L27) is triggered to reset the experiment config when a different experiment engine is selected. During this short span of time, the `experiments` field within the experiment config is undefined and hence the UI crashes. Hence, a fallback array is passed to the `StandardEnsemblerPanel` component if that field is undefined. Additionally, an additional step has been added to the effect to reset both the `route_name_path` and `experiment_mappings` fields when a different experiment engine is selected with a standard ensembler already configured.

2. If a user unsets the experiment engine field on the router edit page, the UI similarly crashes because it continues to render the `StandardExperimentFormGroup` component.
![Screenshot 2022-10-17 at 3 32 58 PM](https://user-images.githubusercontent.com/36802364/196115908-3bd4cd85-4407-4881-ab3d-cef9a8a7bd27.png)
This happens because `ensembler.standard_config` of the router config is still present even after the experiment engine has been unset (set to 'None'). Hence, an additional check has been added to ensure that the `StandardExperimentFormGroup` component does not get displayed when no experiment engine is selected (the config nonetheless remains in memory until the user completes the router edit/save operation).