### PR TITLE
Bugfix: Fix experiments landing page path

### DIFF
--- a/ui/src/AppRoutes.js
+++ b/ui/src/AppRoutes.js
@@ -25,7 +25,7 @@ const AppRoutes = () => {
           {/* ENSEMBLERS */}
           <Route path="ensemblers" element={<ListEnsemblersView />} />
           {/* EXPERIMENTS */}
-          <Route path="experiments" element={<ExperimentsRouter />} />
+          <Route path="experiments/*" element={<ExperimentsRouter />} />
           {/* ROUTERS */}
           <Route path="routers">
             {/* LIST */}


### PR DESCRIPTION
This PR is a follow up from https://github.com/caraml-dev/turing/pull/265, which missed a `/*` pattern in the experiments landing page, to allow matching the nested routes exposed by the remote component correctly.

