### PR TITLE
Bugfix: Navigation with react-router-dom

### DIFF
--- a/ui/src/Home.js
+++ b/ui/src/Home.js
@@ -1,11 +1,14 @@
-import React, { Fragment } from "react";
+import React, { Fragment, useContext } from "react";
 import { EuiPageTemplate } from "@elastic/eui";
+import { ProjectsContext } from "@gojek/mlp-ui";
+import { Navigate } from "react-router-dom";
 import { useConfig } from "./config";
 
 const Home = () => {
   const { appConfig } = useConfig();
+  const { currentProject } = useContext(ProjectsContext);
 
-  return (
+  return !currentProject ? (
     <EuiPageTemplate>
       <EuiPageTemplate.EmptyPrompt
         iconType={appConfig.appIcon}
@@ -17,6 +20,8 @@ const Home = () => {
         }
       />
     </EuiPageTemplate>
+  ) : (
+    <Navigate to={`projects/${currentProject.id}`} replace={true} />
   );
 };
 

--- a/ui/src/PrivateLayout.js
+++ b/ui/src/PrivateLayout.js
@@ -27,8 +27,7 @@ export const PrivateLayout = () => {
                     navigate(urlJoin(currentApp?.href, "projects", pId, "routers"))
                   }
                   docLinks={appConfig.docsUrl}
-                />
-              )}
+                />)}
             </ApplicationsContext.Consumer>
             <Outlet />
           </EnvironmentsContextProvider>

--- a/ui/src/PrivateLayout.js
+++ b/ui/src/PrivateLayout.js
@@ -23,12 +23,12 @@ export const PrivateLayout = () => {
             <ApplicationsContext.Consumer>
               {({ currentApp }) => (
                 <Header
-                  homepage={appConfig.homepage}
                   onProjectSelect={pId =>
                     navigate(urlJoin(currentApp?.href, "projects", pId, "routers"))
                   }
                   docLinks={appConfig.docsUrl}
-                />)}
+                />
+              )}
             </ApplicationsContext.Consumer>
             <Outlet />
           </EnvironmentsContextProvider>


### PR DESCRIPTION
This is a follow up from the previous PRs and addresses some regressions introduced by the first:
* https://github.com/caraml-dev/turing/pull/265
* https://github.com/caraml-dev/turing/pull/271

Fixes the following issues:
* `ui/src/PrivateLayout.js` - Header's homepage should be empty (default "/") so that in the multi-app deployment, clicking the header logo can take us to the MLP landing page.
* `ui/src/Home.js` - Navigating to `/turing` in the deployed app should automatically redirect to the index page for Turing (list routers) if the current project is chosen.