### PR TITLE
Fix and rename make commands for local E2E

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -85,14 +85,14 @@ version:
 # E2E tests
 # ==================================
 
-.PHONY: local-infra
-local-infra:
+.PHONY: build-run-local-api
+build-run-local-api:
 	@echo "Building proprietary experiment engine plugin..."
 	cd ../engines/experiment/examples/plugins/hardcoded && make proprietary-exp-plugin
 	@echo "Building proprietary experiment engine image..."
 	cd ../engines/experiment/examples/plugins/hardcoded && make build-local-proprietary-exp-plugin-image
 	@echo "Building router image..."
-	cd ../engines/router && make build-local-router-image
+	cd ../engines/router && make build-local-router-image DOCKER_REGISTRY=localhost:5000 OVERWRITE_VERSION=latest
 	@echo "Starting Turing API server in a background process..."
 	nohup go run turing/cmd/main.go -config=config-dev.yaml -config=config-dev-exp-engine.yaml &
 	@echo "Started Turing API server on port 8080 in a background process..."

--- a/api/README.md
+++ b/api/README.md
@@ -118,7 +118,7 @@ istio-system      istio-ingressgateway-b7ffbd9c6-kfpl2      1/1     Running   0 
 ---
 Run the following to get Turing API running locally.
 ```bash
-make local-infra
+make build-run-local-api
 ```
 
 Within the make command, couple of steps are taken:
@@ -126,7 +126,7 @@ Within the make command, couple of steps are taken:
 1. Builds the required Turing component Docker images and pushes them to the local registry, mainly:
     - Proprietary experiment engine plugin image
 
-    When building the binary for consumption by Turing's Experiments Service layer, make sure you're using the same GOOS and GOARCH that's compatible with your machine, you can easily pass in the necessary values eg. `make local-infra GOOS=darwin GOARCH=arm64` instead.
+    When building the binary for consumption by Turing's Experiments Service layer, make sure you're using the same GOOS and GOARCH that's compatible with your machine, you can easily pass in the necessary values eg. `make build-run-local-api GOOS=darwin GOARCH=arm64` instead.
     - Router image
 
     Alternatively, use one of our images [here](https://github.com/caraml-dev/turing/pkgs/container/turing%2Fturing-router).

--- a/engines/experiment/examples/plugins/hardcoded/Makefile
+++ b/engines/experiment/examples/plugins/hardcoded/Makefile
@@ -22,6 +22,7 @@ build-image: vendor
 .PHONY: proprietary-exp-plugin
 proprietary-exp-plugin:
 	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o ./bin/example-plugin ./cmd/main.go
+	mkdir -p ../../../../../api/bin
 	ln -sf ${PWD}/bin/example-plugin ../../../../../api/bin/example-plugin
 
 .PHONY: build-local-proprietary-exp-plugin-image

--- a/engines/router/Makefile
+++ b/engines/router/Makefile
@@ -97,9 +97,8 @@ swagger-ui:
 
 
 .PHONY: build-local-router-image
-build-local-router-image: vendor
-	$(MAKE) build-image DOCKER_REGISTRY=localhost:5000 OVERWRITE_VERSION=latest
-	docker push $(IMAGE_TAG)
+build-local-router-image: vendor build-image
+	docker push ${DOCKER_REGISTRY}/turing-router:${OVERWRITE_VERSION}
 
 
 #   R E V I E W   R E Q U I R E D

--- a/engines/router/Makefile
+++ b/engines/router/Makefile
@@ -98,7 +98,7 @@ swagger-ui:
 
 .PHONY: build-local-router-image
 build-local-router-image: vendor build-image
-	docker push ${DOCKER_REGISTRY}/turing-router:${OVERWRITE_VERSION}
+	docker push $(IMAGE_TAG)
 
 
 #   R E V I E W   R E Q U I R E D


### PR DESCRIPTION
Fix incorrect `make build-local-router-image` where `IMAGE_TAG` is empty when executing the following:
```
docker push $(IMAGE_TAG)
```

Also, better naming of Make command.