### PR TITLE
bugfix router endpoint in db

### DIFF
--- a/api/turing/models/router.go
+++ b/api/turing/models/router.go
@@ -2,6 +2,9 @@ package models
 
 import (
 	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
 )
 
 type RouterStatus string
@@ -57,4 +60,18 @@ func (r *Router) SetCurrRouterVersion(routerVersion *RouterVersion) {
 func (r *Router) ClearCurrRouterVersion() {
 	r.ClearCurrRouterVersionID()
 	r.CurrRouterVersion = nil
+}
+
+// RouterResponse is an alias for the Router, to enable custom marshaling
+type RouterResponse Router
+
+// MarshalJSON is a custom marshaling function for the Router, to manipulate the
+// endpoint.
+func (r *Router) MarshalJSON() ([]byte, error) {
+	response := RouterResponse(*r)
+	// Append the path to the endpoint
+	if response.Endpoint != "" && strings.HasPrefix(response.Endpoint, "http") {
+		response.Endpoint = fmt.Sprintf("%s/v1/predict", response.Endpoint)
+	}
+	return json.Marshal(response)
 }

--- a/api/turing/models/router_test.go
+++ b/api/turing/models/router_test.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"database/sql"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,4 +35,80 @@ func TestClearCurrRouterVersion(t *testing.T) {
 	// Validate
 	assert.True(t, router.CurrRouterVersion == nil)
 	assert.Equal(t, sql.NullInt32{Int32: int32(0), Valid: false}, router.CurrRouterVersionID)
+}
+
+func TestRouterMarshalJSON(t *testing.T) {
+	tests := map[string]struct {
+		router   Router
+		expected string
+	}{
+		"http endpoint": {
+			router: Router{
+				Model: Model{
+					ID: 1,
+				},
+				ProjectID:     2,
+				Endpoint:      "http://test-endpoint",
+				MonitoringURL: "http://www.example.com",
+			},
+			expected: `{
+				"id": 1,
+				"created_at": "0001-01-01T00:00:00Z",
+				"updated_at": "0001-01-01T00:00:00Z",
+				"project_id": 2,
+				"monitoring_url": "http://www.example.com",
+				"environment_name": "",
+				"name": "",
+				"status": "",
+				"endpoint": "http://test-endpoint/v1/predict"
+			}`,
+		},
+		"grpc endpoint": {
+			router: Router{
+				Model: Model{
+					ID: 1,
+				},
+				ProjectID:     2,
+				Endpoint:      "test-endpoint:80",
+				MonitoringURL: "http://www.example.com",
+			},
+			expected: `{
+				"id": 1,
+				"created_at": "0001-01-01T00:00:00Z",
+				"updated_at": "0001-01-01T00:00:00Z",
+				"project_id": 2,
+				"monitoring_url": "http://www.example.com",
+				"environment_name": "",
+				"name": "",
+				"status": "",
+				"endpoint": "test-endpoint:80"
+			}`,
+		},
+		"no endpoint": {
+			router: Router{
+				Model: Model{
+					ID: 1,
+				},
+				ProjectID: 2,
+			},
+			expected: `{
+				"id": 1,
+				"created_at": "0001-01-01T00:00:00Z",
+				"updated_at": "0001-01-01T00:00:00Z",
+				"project_id": 2,
+				"environment_name": "",
+				"name": "",
+				"status": "",
+				"monitoring_url": ""
+			}`,
+		},
+	}
+
+	for name, data := range tests {
+		t.Run(name, func(t *testing.T) {
+			byteData, err := json.Marshal(&data.router)
+			assert.NoError(t, err)
+			assert.JSONEq(t, data.expected, string(byteData))
+		})
+	}
 }

--- a/api/turing/service/router_deployment_service.go
+++ b/api/turing/service/router_deployment_service.go
@@ -218,10 +218,12 @@ func (ds *deploymentService) DeployRouterVersion(
 		eventsCh.Write(models.NewErrorEvent(
 			models.EventStageUpdatingEndpoint, "failed to update router endpoint: %s", err.Error()))
 	}
+
+	// only base endpoint is returned, models/router.go will unmarshall with /v1/predict for http routers
 	if routerVersion.Protocol == routerConfig.UPI {
 		return routerEndpoint.Endpoint + ":80", err
 	}
-	return fmt.Sprintf("http://%s/v1/predict", routerEndpoint.Endpoint), err
+	return fmt.Sprintf("http://%s", routerEndpoint.Endpoint), err
 }
 
 // UndeployRouterVersion removes the deployed router, if exists. Else, an error is returned.

--- a/api/turing/service/router_deployment_service_test.go
+++ b/api/turing/service/router_deployment_service_test.go
@@ -246,7 +246,7 @@ func TestDeployEndpoint(t *testing.T) {
 	)
 
 	assert.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("http://%s-router.models.example.com/v1/predict", routerVersion.Router.Name), endpoint)
+	assert.Equal(t, fmt.Sprintf("http://%s-router.models.example.com", routerVersion.Router.Name), endpoint)
 	controller.AssertCalled(t, "CreateNamespace", mock.Anything, testNamespace)
 	controller.AssertCalled(t, "ApplyPersistentVolumeClaim", mock.Anything,
 		testNamespace, &cluster.PersistentVolumeClaim{Name: "pvc"})


### PR DESCRIPTION
## Description

After changing the implementation  in https://github.com/caraml-dev/turing/pull/255, `api/turing/service/router_deployment_service.go` , the endpoints are persisted with `/v1/predict` in the db. This is a problem as Turing can support more than one specific endpoint (/v1/batch_predict)

HTTP endpoint are expected to start with `http`, GRPC endpoint to start with host and end with port appended.

## Changing
1. Reverting `api/turing/service/router_deployment_service.go` to not prepend /v1/predict
2. Add custom marshalling in `models/router.go` to append `/v1/predict`, API calls will then get `/v1/predict`
3. Added unit test `models/router.go` to test http/grpc/nil endpoint

## Testing
Tested local, one UPI Router (id 1) and HTTP Router (id 2)

![Screenshot 2022-11-16 at 11 11 11 AM](https://user-images.githubusercontent.com/30390872/202077971-1b74ac48-7d47-463d-839f-9e2f1096f0a3.png)

API calls, `v1/predict` appended to HTTP endpoint only
![Screenshot 2022-11-16 at 11 11 57 AM](https://user-images.githubusercontent.com/30390872/202077984-7b187d96-78ac-415d-b1df-44b8e3f8ff98.png)


