### PR TITLE
Update traffic rule names in fiber config

### DIFF
--- a/api/turing/cluster/servicebuilder/router.go
+++ b/api/turing/cluster/servicebuilder/router.go
@@ -448,8 +448,8 @@ func buildTrafficSplittingFiberConfig(
 
 	// iterate over traffic rules and generated nested routed and
 	// config for traffic splitting routing strategy
-	for idx, rule := range rules {
-		routeID := fmt.Sprintf("traffic-split-%d", idx)
+	for _, rule := range rules {
+		routeID := rule.Name
 
 		var ruleRoutes models.Routes
 		for _, rID := range rule.Routes {

--- a/api/turing/testdata/cluster/servicebuilder/router_configmap_traffic_splitting.yml
+++ b/api/turing/testdata/cluster/servicebuilder/router_configmap_traffic_splitting.yml
@@ -28,7 +28,7 @@ routes:
         treatment: treatment
     type: fiber.DefaultTuringRoutingStrategy
   type: EAGER_ROUTER
-- id: traffic-split-0
+- id: rule-1
   routes:
   - endpoint: http://example.com/treatment-a
     id: treatment-a
@@ -61,7 +61,7 @@ routes:
         treatment: treatment
     type: fiber.DefaultTuringRoutingStrategy
   type: EAGER_ROUTER
-- id: traffic-split-1
+- id: rule-2
   routes:
   - endpoint: http://example.com/treatment-b
     id: treatment-b
@@ -94,7 +94,7 @@ routes:
         treatment: treatment
     type: fiber.DefaultTuringRoutingStrategy
   type: EAGER_ROUTER
-- id: traffic-split-2
+- id: default-traffic-rule
   routes:
   - endpoint: http://example.com/control
     id: control
@@ -137,15 +137,15 @@ strategy:
         operator: in
         values:
         - region-a
-      route_id: traffic-split-0
+      route_id: rule-1
     - conditions:
       - field: X-Region
         field_source: header
         operator: in
         values:
         - region-b
-      route_id: traffic-split-1
+      route_id: rule-2
     - conditions: []
-      route_id: traffic-split-2
+      route_id: default-traffic-rule
   type: fiber.TrafficSplittingStrategy
 type: LAZY_ROUTER


### PR DESCRIPTION
Updating the Fiber config builder to use the user-defined traffic rule name as opposed to `traffic-split-X`. This will help propagate the user-defined names to the custom metric `traffic_rule` label introduced in https://github.com/caraml-dev/turing/pull/280.