### PR TITLE
Add env var to manually release SDK as v0.7.1

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -102,7 +102,7 @@ jobs:
         working-directory: ./sdk
         run: |
           make setup
-          make build
+          OVERWRITE_VERSION=0.7.1 make build
 
       - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Context
Due to an incorrect distribution of the Turing SDK being previously released as `v0.7.0`, as well as vertagen being unable to determine the correct version tag of the next release of the Turing SDK, this PR introduces an env var to the Turing SDK CD pipeline to manually overwrite the version number of the release as `v0.7.1`. 

## Modifications
- `.github/workflows/sdk.yaml` - Addition of the `OVERWRITE_VERSION` env var to the `make build` command of the CD pipeline