### PR TITLE
Remove env var to release SDK manually

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -102,7 +102,7 @@ jobs:
         working-directory: ./sdk
         run: |
           make setup
-          OVERWRITE_VERSION=0.7.1 make build
+          make build
 
       - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Context 
In PR #294, a temporary change was made to allow the SDK to be released with a version that's manually specified. This PR reverts the changes made in that PR.

## Modifications 
- `.github/workflows/sdk.yaml` - Removal of the env var `OVERWRITE_VERSION` 