### PR TITLE
Add Python 3.10 support

### DIFF
--- a/.github/workflows/pyfunc-ensembler-job.yaml
+++ b/.github/workflows/pyfunc-ensembler-job.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     
     steps:
       - uses: actions/checkout@v2
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     needs:
       - release-rules
       - test

--- a/.github/workflows/pyfunc-ensembler-service.yaml
+++ b/.github/workflows/pyfunc-ensembler-service.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     needs:
       - release-rules
       - test

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     
     defaults:
       run:

--- a/engines/pyfunc-ensembler-job/Dockerfile
+++ b/engines/pyfunc-ensembler-job/Dockerfile
@@ -45,7 +45,7 @@ RUN apt-get update --allow-releaseinfo-change-suite -q && \
 
 # Install gcloud SDK
 ENV PATH=$PATH:/google-cloud-sdk/bin
-ARG GCLOUD_VERSION=332.0.0
+ARG GCLOUD_VERSION=410.0.0
 
 RUN wget -qO- \
     https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GCLOUD_VERSION}-linux-x86_64.tar.gz | \

--- a/engines/pyfunc-ensembler-job/Dockerfile
+++ b/engines/pyfunc-ensembler-job/Dockerfile
@@ -2,8 +2,8 @@ ARG SPARK_VERSION=v3.0.0
 
 FROM gcr.io/spark-operator/spark-py:$SPARK_VERSION
 
-ARG SPARK_OPERATOR_VERSION=v1beta2-1.2.2-3.0.0
-ARG SPARK_BQ_CONNECTOR_VERSION=0.19.1
+ENV SPARK_OPERATOR_VERSION=v1beta2-1.3.7-3.1.1
+ENV SPARK_BQ_CONNECTOR_VERSION=0.27.0
 
 # Reset to root to include spark dependencies
 USER 0
@@ -12,7 +12,7 @@ RUN rm $SPARK_HOME/jars/guava-14.0.1.jar
 ADD https://repo1.maven.org/maven2/com/google/guava/guava/23.0/guava-23.0.jar \
     $SPARK_HOME/jars
 # Add the connector jar needed to access Google Cloud Storage using the Hadoop FileSystem API.
-ADD https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0.1.jar \
+ADD https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.2.8.jar \
     $SPARK_HOME/jars
 ADD https://repo1.maven.org/maven2/com/google/cloud/spark/spark-bigquery-with-dependencies_2.12/${SPARK_BQ_CONNECTOR_VERSION}/spark-bigquery-with-dependencies_2.12-${SPARK_BQ_CONNECTOR_VERSION}.jar \
     $SPARK_HOME/jars

--- a/engines/pyfunc-ensembler-job/Dockerfile
+++ b/engines/pyfunc-ensembler-job/Dockerfile
@@ -68,18 +68,15 @@ USER ${USER}
 WORKDIR $HOME
 
 # Install miniconda
-ARG CONDA_VERSION=py38_4.9.2
-ARG CONDA_MD5=122c8c9beb51e124ab32a0fa6426c656
-ENV CONDA_DIR $HOME/miniconda3
-ENV PATH $CONDA_DIR/bin:$PATH
+ENV CONDA_DIR ${HOME}/miniconda3
+ENV PATH ${CONDA_DIR}/bin:$PATH
+ENV MINIFORGE_VERSION=4.14.0-0
 
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh -O miniconda.sh && \
-    echo "$CONDA_MD5  miniconda.sh" > miniconda.md5 && \
-    if ! md5sum --status -c miniconda.md5; then exit 1; fi && \
-    sh miniconda.sh -b -p $CONDA_DIR && \
-    rm miniconda.sh miniconda.md5 && \
-    echo "source $CONDA_DIR/etc/profile.d/conda.sh" >> $HOME/.bashrc && \
-    $CONDA_DIR/bin/conda clean -afy
+RUN wget --quiet https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/Miniforge3-${MINIFORGE_VERSION}-Linux-x86_64.sh -O miniconda.sh && \
+    /bin/bash miniconda.sh -b -p ${CONDA_DIR} && \
+    rm ~/miniconda.sh && \
+    $CONDA_DIR/bin/conda clean -afy && \
+    echo "source $CONDA_DIR/etc/profile.d/conda.sh" >> $HOME/.bashrc
 
 # Copy PySpark application
 ENV PROJECT_DIR $HOME/batch-ensembler

--- a/engines/pyfunc-ensembler-job/Dockerfile
+++ b/engines/pyfunc-ensembler-job/Dockerfile
@@ -86,7 +86,7 @@ ENV PROJECT_DIR $HOME/batch-ensembler
 RUN mkdir -p $PROJECT_DIR
 COPY --chown=$UID:$GID . $PROJECT_DIR/
 # Hack to ensure that it's compatible with the ../../sdk stated in requirements.txt
-COPY ./temp-deps/sdk $PROJECT_DIR/../../sdk
+COPY --chown=$UID:$GID ./temp-deps/sdk $PROJECT_DIR/../../sdk
 
 # Setup base conda environment
 ARG PYTHON_VERSION

--- a/engines/pyfunc-ensembler-job/env-3.10.yaml
+++ b/engines/pyfunc-ensembler-job/env-3.10.yaml
@@ -1,0 +1,8 @@
+name: pyfunc-ensembler-job
+dependencies:
+  - python=3.10.*
+  - pip=22.2.2
+  - pip:
+      - -r requirements.txt
+      - --extra-index-url=https://test.pypi.org/simple
+      - --trusted-host=test.pypi.org

--- a/engines/pyfunc-ensembler-job/env-3.7.yaml
+++ b/engines/pyfunc-ensembler-job/env-3.7.yaml
@@ -1,7 +1,7 @@
 name: pyfunc-ensembler-job
 dependencies:
   - python=3.7.*
-  - pip=21.2.2
+  - pip=22.2.2
   - pip:
       - -r requirements.txt
       - --extra-index-url=https://test.pypi.org/simple

--- a/engines/pyfunc-ensembler-job/env-3.8.yaml
+++ b/engines/pyfunc-ensembler-job/env-3.8.yaml
@@ -1,7 +1,7 @@
 name: pyfunc-ensembler-job
 dependencies:
   - python=3.8.*
-  - pip=21.2.2
+  - pip=22.2.2
   - pip:
       - -r requirements.txt
       - --extra-index-url=https://test.pypi.org/simple

--- a/engines/pyfunc-ensembler-job/env-3.9.yaml
+++ b/engines/pyfunc-ensembler-job/env-3.9.yaml
@@ -1,7 +1,7 @@
 name: pyfunc-ensembler-job
 dependencies:
   - python=3.9.*
-  - pip=21.2.2
+  - pip=22.2.2
   - pip:
       - -r requirements.txt
       - --extra-index-url=https://test.pypi.org/simple

--- a/engines/pyfunc-ensembler-job/requirements.txt
+++ b/engines/pyfunc-ensembler-job/requirements.txt
@@ -2,11 +2,11 @@ cloudpickle==2.0.0
 google-cloud-storage>=1.37.0
 jinjasql==0.1.8
 jinja2==3.0.3
-mlflow==1.14.1
+mlflow>=1.2.0,<=1.23.0
 numpy==1.21.6
 pandas==1.3.5
 py4j==0.10.9
-pyarrow==6.0.1
+pyarrow>=0.14.1,<=9.0.0
 pyspark==3.0.1
 pyyaml==6.0
 file:../../sdk

--- a/engines/pyfunc-ensembler-job/requirements.txt
+++ b/engines/pyfunc-ensembler-job/requirements.txt
@@ -6,7 +6,7 @@ mlflow==1.14.1
 numpy==1.21.6
 pandas==1.3.5
 py4j==0.10.9
-pyarrow==3.0.0
+pyarrow==6.0.1
 pyspark==3.0.1
 pyyaml==5.4.1
 file:../../sdk

--- a/engines/pyfunc-ensembler-job/requirements.txt
+++ b/engines/pyfunc-ensembler-job/requirements.txt
@@ -4,7 +4,7 @@ jinjasql==0.1.8
 jinja2==3.0.3
 mlflow==1.14.1
 numpy==1.21.6
-pandas==1.2.2
+pandas==1.3.5
 py4j==0.10.9
 pyarrow==3.0.0
 pyspark==3.0.1

--- a/engines/pyfunc-ensembler-job/requirements.txt
+++ b/engines/pyfunc-ensembler-job/requirements.txt
@@ -8,5 +8,5 @@ pandas==1.3.5
 py4j==0.10.9
 pyarrow==6.0.1
 pyspark==3.0.1
-pyyaml==5.4.1
+pyyaml==6.0
 file:../../sdk

--- a/engines/pyfunc-ensembler-job/setup.py
+++ b/engines/pyfunc-ensembler-job/setup.py
@@ -20,5 +20,5 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=requirements,
     dev_requirements=dev_requirements,
-    python_requires=">=3.7,<= 3.10.*",
+    python_requires=">=3.7,<3.11",
 )

--- a/engines/pyfunc-ensembler-job/setup.py
+++ b/engines/pyfunc-ensembler-job/setup.py
@@ -20,5 +20,5 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=requirements,
     dev_requirements=dev_requirements,
-    python_requires=">=3.7,!=3.11.*",
+    python_requires=">=3.7,<= 3.10.*",
 )

--- a/engines/pyfunc-ensembler-job/setup.py
+++ b/engines/pyfunc-ensembler-job/setup.py
@@ -20,5 +20,5 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=requirements,
     dev_requirements=dev_requirements,
-    python_requires="==3.7.*",
+    python_requires=">=3.7,!=3.11.*",
 )

--- a/engines/pyfunc-ensembler-service/env-3.10.yaml
+++ b/engines/pyfunc-ensembler-service/env-3.10.yaml
@@ -1,0 +1,8 @@
+name: pyfunc-ensembler-service
+dependencies:
+  - python=3.10.*
+  - pip=22.2.2
+  - pip:
+      - -r requirements.txt
+      - --extra-index-url=https://test.pypi.org/simple
+      - --trusted-host=test.pypi.org

--- a/engines/pyfunc-ensembler-service/setup.py
+++ b/engines/pyfunc-ensembler-service/setup.py
@@ -20,5 +20,5 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=requirements,
     dev_requirements=dev_requirements,
-    python_requires=">=3.7,<= 3.10.*",
+    python_requires=">=3.7,<3.11",
 )

--- a/engines/pyfunc-ensembler-service/setup.py
+++ b/engines/pyfunc-ensembler-service/setup.py
@@ -20,5 +20,5 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=requirements,
     dev_requirements=dev_requirements,
-    python_requires=">=3.7,!=3.11.*",
+    python_requires=">=3.7,<= 3.10.*",
 )

--- a/engines/pyfunc-ensembler-service/setup.py
+++ b/engines/pyfunc-ensembler-service/setup.py
@@ -20,5 +20,5 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=requirements,
     dev_requirements=dev_requirements,
-    python_requires="==3.7.*",
+    python_requires=">=3.7,!=3.11.*",
 )

--- a/sdk/requirements.txt
+++ b/sdk/requirements.txt
@@ -1,12 +1,12 @@
 cloudpickle==2.0.0
 deprecation==2.1.0
 fire
-google-auth>=1.30.0,<2.0dev
-google-cloud-storage>=1.37.0
-mlflow==1.14.1
+google-auth>=1.11.0
+google-cloud-storage>=1.19.0
+mlflow>=1.2.0,<=1.23.0
 numpy
 pandas
-protobuf>=3.0.0,<4.0.0
+protobuf>=3.0.0,<4.0.0dev
 python_dateutil>=2.5.3
 requests
 urllib3>=1.25.3

--- a/sdk/requirements.txt
+++ b/sdk/requirements.txt
@@ -3,7 +3,7 @@ deprecation==2.1.0
 fire
 google-auth>=1.30.0,<2.0dev
 google-cloud-storage>=1.37.0
-mlflow>=1.2.0,<=1.23.0
+mlflow==1.14.1
 numpy
 pandas
 protobuf>=3.0.0,<4.0.0

--- a/sdk/requirements.txt
+++ b/sdk/requirements.txt
@@ -3,10 +3,10 @@ deprecation==2.1.0
 fire
 google-auth>=1.30.0,<2.0dev
 google-cloud-storage>=1.37.0
-mlflow==1.14.1
-numpy==1.21.6
-pandas==1.2.2
-protobuf==3.20.1
-python-dateutil
-requests==2.25.1
-urllib3 >= 1.25.3
+mlflow>=1.2.0,<=1.23.0
+numpy
+pandas
+protobuf>=3.0.0,<4.0.0
+python_dateutil>=2.5.3
+requests
+urllib3>=1.25.3

--- a/sdk/samples/router/general.py
+++ b/sdk/samples/router/general.py
@@ -200,6 +200,13 @@ def main(turing_api: str, project: str):
             id="fee-fi-fo-fum", endpoint="http://fox-says.fee-fi-fo-fum", timeout="20ms"
         )
     )
+    my_router_config.rules.append(
+        TrafficRule(
+            name="giant-rule",
+            conditions=[HeaderTrafficRuleCondition(field="name", values=["giant"])],
+            routes=["fee-fi-fo-fum"],
+        ),
+    )
 
     # 4. Update the router with the new router config
     my_router.update(my_router_config)

--- a/sdk/setup.py
+++ b/sdk/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=requirements,
     extras_require={"dev": dev_requirements},
-    python_requires=">=3.7,!=3.10.*",
+    python_requires=">=3.7,!=3.11.*",
     long_description=pathlib.Path("./docs/README.md").read_text(),
     long_description_content_type="text/markdown",
 )

--- a/sdk/setup.py
+++ b/sdk/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=["docs", "e2e", "samples", "tests"]),
     install_requires=requirements,
     extras_require={"dev": dev_requirements},
-    python_requires=">=3.7,<= 3.10.*",
+    python_requires=">=3.7,<3.11",
     long_description=pathlib.Path("./docs/README.md").read_text(),
     long_description_content_type="text/markdown",
 )

--- a/sdk/setup.py
+++ b/sdk/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=["docs", "e2e", "samples", "tests"]),
     install_requires=requirements,
     extras_require={"dev": dev_requirements},
-    python_requires=">=3.7,!=3.11.*",
+    python_requires=">=3.7,<= 3.10.*",
     long_description=pathlib.Path("./docs/README.md").read_text(),
     long_description_content_type="text/markdown",
 )

--- a/sdk/setup.py
+++ b/sdk/setup.py
@@ -22,7 +22,7 @@ with pathlib.Path("requirements.dev.txt").open() as dev_requirements_test:
 setuptools.setup(
     name="turing-sdk",
     version=version,
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=["docs", "e2e", "samples", "tests"]),
     install_requires=requirements,
     extras_require={"dev": dev_requirements},
     python_requires=">=3.7,!=3.11.*",

--- a/sdk/tests/fixtures/mlflow.py
+++ b/sdk/tests/fixtures/mlflow.py
@@ -8,7 +8,7 @@ def mock_mlflow(responses, experiment_name, experiment_id, run_id, artifact_uri)
     responses.add(
         method="GET",
         url=f"/api/2.0/mlflow/experiments/get-by-name?experiment_name={quote_plus(experiment_name)}",
-        body=json.dumps({"experiment": {"id": experiment_id, "name": experiment_name}}),
+        body=json.dumps({"experiment": {"id": experiment_id, "name": experiment_name, "lifecycle_stage": "active"}}),
         match_querystring=True,
         status=200,
         content_type="application/json",


### PR DESCRIPTION
## Context
With the introduction of Python 3.10 for over a year, it is high time to introduce support for this version for the Turing SDK. This PR introduces changes needed to accommodate Python 3.10 in the SDK as well as all components that depend on it. 

Additionally, this PR modifies the existing CI/CD workflows that cover this new Python version that Turing will be supporting.