### PR TITLE
revert fiber to 2.0

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-playground/validator v9.31.0+incompatible
 	github.com/go-playground/validator/v10 v10.9.0
-	github.com/gojek/fiber v0.2.1-rc1
+	github.com/gojek/fiber v0.2.0
 	github.com/gojek/merlin v0.0.0
 	github.com/gojek/mlp v1.4.7
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3

--- a/api/go.sum
+++ b/api/go.sum
@@ -702,8 +702,8 @@ github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/gojek/fiber v0.2.1-rc1 h1:+am8cSlCBxUowhqF9DPrgQEeHctkdi8RV8R8F4Wajgo=
-github.com/gojek/fiber v0.2.1-rc1/go.mod h1:R5cRkUnXdTLpdchCkm3lmGJS+nfhPhLDOklRq1T65Jg=
+github.com/gojek/fiber v0.2.0 h1:1lOMFm9rqJpfFpcDT44JSXewuWuFrKZMobWBo+YnEag=
+github.com/gojek/fiber v0.2.0/go.mod h1:R5cRkUnXdTLpdchCkm3lmGJS+nfhPhLDOklRq1T65Jg=
 github.com/gojek/heimdall/v7 v7.0.2/go.mod h1:Z43HtMid7ysSjmsedPTXAki6jcdcNVnjn5pmsTyiMic=
 github.com/gojek/merlin/api v0.0.0-20210723093139-cc0240032d58 h1:8cVTLtTFHjfoTKQyL4sMSnfmTlTJU+Cizfy4hzRl2Tg=
 github.com/gojek/merlin/api v0.0.0-20210723093139-cc0240032d58/go.mod h1:FYMy4bZcts0UkTDE/rgGRWTOG4sUc5NvkljQqw4C8AE=

--- a/engines/router/go.mod
+++ b/engines/router/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/caraml-dev/universal-prediction-interface v0.0.0-20221026045401-50e7d79e4b73
 	github.com/fluent/fluent-logger-golang v1.5.0
 	github.com/go-playground/validator/v10 v10.3.0
-	github.com/gojek/fiber v0.2.1-rc1
+	github.com/gojek/fiber v0.2.0
 	github.com/gojek/mlp v1.4.7
 	github.com/google/go-cmp v0.5.8
 	github.com/google/uuid v1.3.0

--- a/engines/router/go.sum
+++ b/engines/router/go.sum
@@ -220,8 +220,8 @@ github.com/gocql/gocql v0.0.0-20190301043612-f6df8288f9b4/go.mod h1:4Fw1eo5iaEhD
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
-github.com/gojek/fiber v0.2.1-rc1 h1:+am8cSlCBxUowhqF9DPrgQEeHctkdi8RV8R8F4Wajgo=
-github.com/gojek/fiber v0.2.1-rc1/go.mod h1:R5cRkUnXdTLpdchCkm3lmGJS+nfhPhLDOklRq1T65Jg=
+github.com/gojek/fiber v0.2.0 h1:1lOMFm9rqJpfFpcDT44JSXewuWuFrKZMobWBo+YnEag=
+github.com/gojek/fiber v0.2.0/go.mod h1:R5cRkUnXdTLpdchCkm3lmGJS+nfhPhLDOklRq1T65Jg=
 github.com/gojek/mlp v1.4.7 h1:GxqqI0rQxUF4pexCk3aHsd5Mu4o4OnnsbGk+MTnW26Y=
 github.com/gojek/mlp v1.4.7/go.mod h1:3+/YMTxQenxYSvKzOiEio+UBXPheJ4+/5c1MkbYoLwc=
 github.com/golang-migrate/migrate/v4 v4.11.0/go.mod h1:nqbpDbckcYjsCD5I8q5+NI9Tkk7SVcmaF40Ax1eAWhg=


### PR DESCRIPTION
## Description

In fiber 2.0, when Traffic Rules are used with `Selective` routing strategy in standard ensembler setup. Underlying, the router are composed of two nested `lazy router`. With the default `Exhaustive` routing strategy, it is composed of a parent `lazy router` (which is used for traffic splitting) and child `eager router` (to call all routers in parallel).

Fiber 2.1-rc1 fixes the above problem with route request duration metric but introduce another bug to route component metric To explain in context

**Fiber 2.0**
Step 1 Parent layer - lazy router (for both routing strategy)
1. Lazy router calls `TrafficSplittingStrategy` and obtain the traffic rule labels
2. Invoke child common with traffic labels added to context

Step 2a Second layer - eager router (exhaustive strategy)
1. Calls all routes with context passed (contain traffic label, which logs metric correctly)
2. Calls `DefaultTuringRoutingStrategy` and get empty label
3. Return with no labels

Step 2b Second layer - lazy router (selective strategy)
1. Calls `DefaultTuringRoutingStrategy` and get empty label
2. Calls all routes with context passed (contain NO traffic label, as it is pass the label from `DefaultTuringRoutingStrategy` which logs metric incorrectly)
3. Return with no labels

Step 3 Back to first parent layer -  lazy router (for both routing strategy)
1. Both child pass back response with no label
2. Return response with traffic labels from `TrafficSplittingStrategy`

**Fiber 2.1-rc1**
Step 1 Parent layer - lazy router (for both routing strategy), no change from the above
1. Lazy router calls `TrafficSplittingStrategy` and obtain the traffic rule labels
2. Invoke child common with traffic labels added to context

Step 2a Second layer - eager router (exhaustive strategy)
1. Calls all routes with context passed (contain traffic label, which logs metric correctly)
2. Calls `DefaultTuringRoutingStrategy`, get empty label and merge labels with parent's label
4. Return with merged labels

Step 2b Second layer - lazy router (selective strategy)
1. Calls `DefaultTuringRoutingStrategy` , get empty label and merge labels with parent's label
2. Calls all routes with context passed (contain traffic label, as it merged with parent label, which logs metric correctly)
3. Return  with merged labels

Step 3 Back to first parent layer -  lazy router (for both routing strategy)
1. Both child pass back response with merged label (problem occurs here)
2. Return response with traffic labels from `TrafficSplittingStrategy` by merging back return label, causing double labelling

Fundamentally, this behaviour occur due to eager and lazy router calling routes with different sequence.
- eager router call route with parent context, then call strategy
- lazy router call strategy, then call route with strategy context

Hence this PR reverts Fiber 2.1-rc1, until a solution fixes both metrics.