### PR TITLE
Add NodeSelector and TolerationName to ImageBuildingConfig

### DIFF
--- a/api/turing/cluster/job.go
+++ b/api/turing/cluster/job.go
@@ -17,6 +17,7 @@ type Job struct {
 	RestartPolicy           corev1.RestartPolicy
 	Containers              []Container
 	SecretVolumes           []SecretVolume
+	NodeSelector            map[string]string
 }
 
 // Build converts the spec into a Kubernetes spec
@@ -49,6 +50,7 @@ func (j *Job) Build() *batchv1.Job {
 					RestartPolicy: j.RestartPolicy,
 					Containers:    containers,
 					Volumes:       volumes,
+					NodeSelector:  j.NodeSelector,
 				},
 			},
 		},

--- a/api/turing/cluster/job.go
+++ b/api/turing/cluster/job.go
@@ -17,6 +17,7 @@ type Job struct {
 	RestartPolicy           corev1.RestartPolicy
 	Containers              []Container
 	SecretVolumes           []SecretVolume
+	TolerationName          *string
 	NodeSelector            map[string]string
 }
 
@@ -30,6 +31,18 @@ func (j *Job) Build() *batchv1.Job {
 	volumes := []corev1.Volume{}
 	for _, v := range j.SecretVolumes {
 		volumes = append(volumes, v.Build())
+	}
+
+	tolerations := []corev1.Toleration{}
+	if j.TolerationName != nil {
+		tolerations = []corev1.Toleration{
+			{
+				Key:      *j.TolerationName,
+				Operator: corev1.TolerationOpEqual,
+				Value:    "true",
+				Effect:   corev1.TaintEffectNoSchedule,
+			},
+		}
 	}
 
 	return &batchv1.Job{
@@ -50,6 +63,7 @@ func (j *Job) Build() *batchv1.Job {
 					RestartPolicy: j.RestartPolicy,
 					Containers:    containers,
 					Volumes:       volumes,
+					Tolerations:   tolerations,
 					NodeSelector:  j.NodeSelector,
 				},
 			},

--- a/api/turing/cluster/job_test.go
+++ b/api/turing/cluster/job_test.go
@@ -45,6 +45,9 @@ func TestJob(t *testing.T) {
 					Volumes: []corev1.Volume{
 						CreateKubernetesSecretVolume(),
 					},
+					NodeSelector: map[string]string{
+						"node-workload-type": "image",
+					},
 				},
 			},
 		},
@@ -63,6 +66,9 @@ func TestJob(t *testing.T) {
 		},
 		SecretVolumes: []SecretVolume{
 			CreateSecretVolume(),
+		},
+		NodeSelector: map[string]string{
+			"node-workload-type": "image",
 		},
 	}
 

--- a/api/turing/cluster/job_test.go
+++ b/api/turing/cluster/job_test.go
@@ -45,6 +45,14 @@ func TestJob(t *testing.T) {
 					Volumes: []corev1.Volume{
 						CreateKubernetesSecretVolume(),
 					},
+					Tolerations: []corev1.Toleration{
+						{
+							Key:      "tolerate-this",
+							Operator: corev1.TolerationOpEqual,
+							Value:    "true",
+							Effect:   corev1.TaintEffectNoSchedule,
+						},
+					},
 					NodeSelector: map[string]string{
 						"node-workload-type": "image",
 					},
@@ -52,6 +60,8 @@ func TestJob(t *testing.T) {
 			},
 		},
 	}
+
+	tolerationName := "tolerate-this"
 
 	j := Job{
 		Name:                    jobName,
@@ -67,6 +77,7 @@ func TestJob(t *testing.T) {
 		SecretVolumes: []SecretVolume{
 			CreateSecretVolume(),
 		},
+		TolerationName: &tolerationName,
 		NodeSelector: map[string]string{
 			"node-workload-type": "image",
 		},

--- a/api/turing/config/config.go
+++ b/api/turing/config/config.go
@@ -159,6 +159,8 @@ type ImageBuildingConfig struct {
 	BaseImageRef map[string]string `validate:"required"`
 	// KanikoConfig contains the configuration related to the kaniko executor image builder.
 	KanikoConfig KanikoConfig `validate:"required"`
+	// NodeSelector restricts the running of image building jobs to nodes with the specified labels
+	NodeSelector map[string]string
 }
 
 // Resource contains the Kubernetes resource request and limits

--- a/api/turing/config/config.go
+++ b/api/turing/config/config.go
@@ -159,7 +159,9 @@ type ImageBuildingConfig struct {
 	BaseImageRef map[string]string `validate:"required"`
 	// KanikoConfig contains the configuration related to the kaniko executor image builder.
 	KanikoConfig KanikoConfig `validate:"required"`
-	// NodeSelector restricts the running of image building jobs to nodes with the specified labels
+	// TolerationName allow the scheduler to schedule image building jobs with the matching name
+	TolerationName *string
+	// NodeSelector restricts the running of image building jobs to nodes with the specified labels.
 	NodeSelector map[string]string
 }
 

--- a/api/turing/config/config_test.go
+++ b/api/turing/config/config_test.go
@@ -650,6 +650,9 @@ func TestConfigValidate(t *testing.T) {
 						},
 					},
 				},
+				NodeSelector: map[string]string{
+					"node-workload-type": "image",
+				},
 			},
 		},
 		DbConfig: &config.DatabaseConfig{

--- a/api/turing/config/config_test.go
+++ b/api/turing/config/config_test.go
@@ -650,9 +650,6 @@ func TestConfigValidate(t *testing.T) {
 						},
 					},
 				},
-				NodeSelector: map[string]string{
-					"node-workload-type": "image",
-				},
 			},
 		},
 		DbConfig: &config.DatabaseConfig{

--- a/api/turing/imagebuilder/imagebuilder.go
+++ b/api/turing/imagebuilder/imagebuilder.go
@@ -292,7 +292,8 @@ func (ib *imageBuilder) createKanikoJob(
 				SecretName: kanikoSecretName,
 			},
 		},
-		NodeSelector: ib.imageBuildingConfig.NodeSelector,
+		TolerationName: ib.imageBuildingConfig.TolerationName,
+		NodeSelector:   ib.imageBuildingConfig.NodeSelector,
 	}
 
 	return ib.clusterController.CreateJob(

--- a/api/turing/imagebuilder/imagebuilder.go
+++ b/api/turing/imagebuilder/imagebuilder.go
@@ -292,6 +292,7 @@ func (ib *imageBuilder) createKanikoJob(
 				SecretName: kanikoSecretName,
 			},
 		},
+		NodeSelector: ib.imageBuildingConfig.NodeSelector,
 	}
 
 	return ib.clusterController.CreateJob(


### PR DESCRIPTION
## Context
This PR introduces two additional configuration to the `ImageBuildingConfig`:

1. `NodeSelector` which allows operators of the Turing API server to set labels such that the image building jobs (and the pods they spin up) only scheduled on nodes with those labels and,
2. `TolerationName` which allows operators of the Turing API server to set a toleration name such that image building jobs will be deployed with the specified toleration name, allowing them to be scheduled on nodes with the matching taint. 