### PR TITLE
fix json formatting of logs proto

### DIFF
--- a/engines/router/missionctl/server/upi/logutils.go
+++ b/engines/router/missionctl/server/upi/logutils.go
@@ -20,7 +20,7 @@ type grpcRouterResponse struct {
 	err    string
 }
 
-var protoJSONMarshaller = protojson.MarshalOptions{}
+var protoJSONMarshaller = protojson.MarshalOptions{UseProtoNames: true}
 
 func logTuringRouterRequestSummary(
 	ctx context.Context,

--- a/engines/router/missionctl/server/upi/logutils_test.go
+++ b/engines/router/missionctl/server/upi/logutils_test.go
@@ -4,16 +4,23 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/caraml-dev/turing/engines/router/missionctl/config"
+	"github.com/caraml-dev/turing/engines/router/missionctl/log"
+	"github.com/caraml-dev/turing/engines/router/missionctl/log/resultlog"
 	upiv1 "github.com/caraml-dev/universal-prediction-interface/gen/go/grpc/caraml/upi/v1"
 	fiberProtocol "github.com/gojek/fiber/protocol"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/caraml-dev/turing/engines/router/missionctl/errors"
 )
 
-func Test_logTuringRouterRequestSummary(t *testing.T) {
+func TestCopyResponseToLogChannel(t *testing.T) {
 	resp := &upiv1.PredictValuesResponse{}
 	key := "test"
 
@@ -49,6 +56,97 @@ func Test_logTuringRouterRequestSummary(t *testing.T) {
 			close(respCh)
 			data := <-respCh
 			require.Equal(t, tt.expected, data)
+		})
+	}
+}
+
+// TestLogTuringRouterRequestSummary tests that the response and request are parsed into the expected format
+// this include nested proto where underscore separated is expected e.g. prediction_result_table
+func TestLogTuringRouterRequestSummary(t *testing.T) {
+	table := &upiv1.Table{
+		Name: "abc",
+		Rows: []*upiv1.Row{
+			{
+				RowId: "row1",
+				Values: []*upiv1.Value{
+					{
+						DoubleValue: 123.456,
+					},
+				},
+			},
+		},
+	}
+	header := metadata.New(map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	})
+	headerString := "map[key1:value1 key2:value2]"
+
+	tests := []struct {
+		name              string
+		reqHeader         metadata.MD
+		reqBody           *upiv1.PredictValuesRequest
+		resHeader         metadata.MD
+		resBody           *upiv1.PredictValuesResponse
+		expectedReqBody   string
+		expectedReqHeader string
+		expectedResHeader string
+		expectedResBody   string
+	}{
+		{
+			name:      "ok",
+			reqHeader: header,
+			reqBody: &upiv1.PredictValuesRequest{
+				PredictionTable: table,
+			},
+			resHeader: header,
+			resBody: &upiv1.PredictValuesResponse{
+				PredictionResultTable: table,
+			},
+			expectedReqHeader: headerString,
+			expectedResHeader: headerString,
+			expectedReqBody: `{"prediction_table":{"name":"abc", "rows":[{"row_id":"row1", 
+								"values":[{"double_value":123.456}]}]}}`,
+			expectedResBody: `{"prediction_result_table":{"name":"abc", "rows":[{"row_id":"row1", 
+								"values":[{"double_value":123.456}]}]}}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			//Set up observer for test to log entry to console
+			core, collectedLogs := observer.New(zap.InfoLevel)
+			logger := zap.New(core)
+			log.SetGlobalLogger(logger.Sugar())
+			err := resultlog.InitTuringResultLogger(&config.AppConfig{
+				ResultLogger: config.ConsoleLogger,
+			})
+			assert.NoError(t, err)
+
+			//Add response to channel and invoke logging of summary
+			respCh := make(chan grpcRouterResponse, 1)
+			respCh <- grpcRouterResponse{header: tt.reqHeader, body: tt.resBody, key: resultlog.ResultLogKeys.Router}
+			close(respCh)
+			logTuringRouterRequestSummary(context.Background(), time.Now(), tt.reqHeader, tt.reqBody, respCh)
+
+			filteredLogs := collectedLogs.FilterMessage("Turing Request Summary")
+			require.NotZero(t, filteredLogs.Len())
+			for _, log := range filteredLogs.All() {
+				for _, content := range log.Context {
+					if content.Key == "request" {
+						req := content.Interface.(map[string]interface{})
+						header := fmt.Sprintf("%v", req["header"])
+						body := fmt.Sprintf("%v", req["body"])
+						assert.Equal(t, tt.expectedReqHeader, header)
+						assert.JSONEq(t, tt.expectedReqBody, body)
+					} else if content.Key == "router" {
+						req := content.Interface.(map[string]interface{})
+						header := fmt.Sprintf("%v", req["header"])
+						body := fmt.Sprintf("%v", req["response"])
+						assert.Equal(t, tt.expectedResHeader, header)
+						assert.JSONEq(t, tt.expectedResBody, body)
+					}
+				}
+			}
 		})
 	}
 }

--- a/engines/router/missionctl/server/upi/logutils_test.go
+++ b/engines/router/missionctl/server/upi/logutils_test.go
@@ -76,11 +76,6 @@ func TestLogTuringRouterRequestSummary(t *testing.T) {
 			},
 		},
 	}
-	header := metadata.New(map[string]string{
-		"key1": "value1",
-		"key2": "value2",
-	})
-	headerString := "map[key1:value1 key2:value2]"
 
 	tests := []struct {
 		name              string
@@ -94,17 +89,22 @@ func TestLogTuringRouterRequestSummary(t *testing.T) {
 		expectedResBody   string
 	}{
 		{
-			name:      "ok",
-			reqHeader: header,
+			name: "ok",
+			reqHeader: metadata.New(map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			}),
 			reqBody: &upiv1.PredictValuesRequest{
 				PredictionTable: table,
 			},
-			resHeader: header,
+			resHeader: metadata.New(map[string]string{
+				"key3": "value3",
+			}),
 			resBody: &upiv1.PredictValuesResponse{
 				PredictionResultTable: table,
 			},
-			expectedReqHeader: headerString,
-			expectedResHeader: headerString,
+			expectedReqHeader: "map[key1:value1 key2:value2]",
+			expectedResHeader: "map[key3:value3]",
 			expectedReqBody: `{"prediction_table":{"name":"abc", "rows":[{"row_id":"row1", 
 								"values":[{"double_value":123.456}]}]}}`,
 			expectedResBody: `{"prediction_result_table":{"name":"abc", "rows":[{"row_id":"row1", 
@@ -124,7 +124,7 @@ func TestLogTuringRouterRequestSummary(t *testing.T) {
 
 			//Add response to channel and invoke logging of summary
 			respCh := make(chan grpcRouterResponse, 1)
-			respCh <- grpcRouterResponse{header: tt.reqHeader, body: tt.resBody, key: resultlog.ResultLogKeys.Router}
+			respCh <- grpcRouterResponse{header: tt.resHeader, body: tt.resBody, key: resultlog.ResultLogKeys.Router}
 			close(respCh)
 			logTuringRouterRequestSummary(context.Background(), time.Now(), tt.reqHeader, tt.reqBody, respCh)
 


### PR DESCRIPTION
## Description 
This PR add marshal option to the protojson marshaller to use proto name (separate words by underscore instead of camelCase) and a test for logging that will assert the format. Also to address a previous [PR](https://github.com/caraml-dev/turing/pull/301/files)  `engines/router/missionctl/server/upi/logutils.go` whereby the request was logged as response without noticing.

Using the default marshaller, the proto keys are camelcase which is not consistent
![Screenshot 2023-01-18 at 6 34 34 PM](https://user-images.githubusercontent.com/30390872/213152963-ae5636a4-bfc2-41ea-9c6e-dc10c456057f.png)

