### PR TITLE
Refresh credentials in SDK on load

### DIFF
--- a/sdk/tests/fixtures/mlflow.py
+++ b/sdk/tests/fixtures/mlflow.py
@@ -8,7 +8,15 @@ def mock_mlflow(responses, experiment_name, experiment_id, run_id, artifact_uri)
     responses.add(
         method="GET",
         url=f"/api/2.0/mlflow/experiments/get-by-name?experiment_name={quote_plus(experiment_name)}",
-        body=json.dumps({"experiment": {"id": experiment_id, "name": experiment_name, "lifecycle_stage": "active"}}),
+        body=json.dumps(
+            {
+                "experiment": {
+                    "id": experiment_id,
+                    "name": experiment_name,
+                    "lifecycle_stage": "active",
+                }
+            }
+        ),
         match_querystring=True,
         status=200,
         content_type="application/json",

--- a/sdk/turing/session.py
+++ b/sdk/turing/session.py
@@ -56,11 +56,15 @@ class TuringSession:
 
         if use_google_oauth:
             import google.auth
+            from google.auth.transport.requests import Request
             from google.auth.transport.urllib3 import urllib3, AuthorizedHttp
 
-            credentials, project = google.auth.default(
-                scopes=TuringSession.OAUTH_SCOPES
-            )
+            # Load default credentials
+            credentials, _ = google.auth.default(scopes=TuringSession.OAUTH_SCOPES)
+            # Refresh credentials, in case it's coming from Compute Engine.
+            # See: https://github.com/googleapis/google-auth-library-python/issues/1211
+            credentials.refresh(Request())
+
             authorized_http = AuthorizedHttp(credentials, urllib3.PoolManager())
             self._api_client.rest_client.pool_manager = authorized_http
 


### PR DESCRIPTION
When authentication is enabled and the Google Auth credentials are loaded, the SDK is now made to refresh the credentials, to get around the following issue which affects Compute Engine workload identity: https://github.com/googleapis/google-auth-library-python/issues/1211

Related PR on Merlin: https://github.com/gojek/merlin/pull/339