### PR TITLE
Bugfix: Throw error when a router is created with an nop exp engine and a standard ensembler

### DIFF
--- a/api/e2e/test/config/config.go
+++ b/api/e2e/test/config/config.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/gavv/httpexpect/v2"
-	"github.com/go-playground/validator"
+	"github.com/go-playground/validator/v10"
 	"github.com/gojek/mlp/api/pkg/vault"
 	"github.com/mitchellh/mapstructure"
 	"github.com/ory/viper"

--- a/api/go.mod
+++ b/api/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/gavv/httpexpect/v2 v2.3.1
 	github.com/getkin/kin-openapi v0.76.0
 	github.com/ghodss/yaml v1.0.0
-	github.com/go-playground/validator v9.31.0+incompatible
 	github.com/go-playground/validator/v10 v10.11.1
 	github.com/gojek/fiber v0.2.0
 	github.com/gojek/merlin v0.0.0
@@ -92,6 +91,7 @@ require (
 	github.com/go-openapi/validate v0.19.7 // indirect
 	github.com/go-playground/locales v0.14.0 // indirect
 	github.com/go-playground/universal-translator v0.18.0 // indirect
+	github.com/go-playground/validator v9.31.0+incompatible // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect

--- a/api/turing/validation/validator.go
+++ b/api/turing/validation/validator.go
@@ -287,6 +287,19 @@ func validateConditionOrthogonality(
 	}
 }
 
+func ValidateStdEnsemblerNotConfiguredForNopExpEngine(
+	sl validator.StructLevel,
+	ensembler *models.Ensembler,
+	experimentEngine *request.ExperimentEngineConfig,
+) {
+	if ensembler != nil && ensembler.Type == models.EnsemblerStandardType {
+		if experimentEngine.Type == models.ExperimentEngineTypeNop {
+			sl.ReportError(experimentEngine.Type, "Type", "Type",
+				"should not be nop when a standard ensembler is configured", "")
+		}
+	}
+}
+
 func validateRouterConfig(sl validator.StructLevel) {
 	router := sl.Current().Interface().(request.RouterConfig)
 	instance := sl.Validator()
@@ -370,10 +383,5 @@ func validateRouterConfig(sl validator.StructLevel) {
 	}
 
 	// Validate that a non-nop experiment engine is used if a standard ensembler is set
-	if router.Ensembler != nil && router.Ensembler.Type == models.EnsemblerStandardType {
-		if router.ExperimentEngine.Type == models.ExperimentEngineTypeNop {
-			sl.ReportError(router.ExperimentEngine.Type, "Type", "Type",
-				"should not be nop when a standard ensembler is configured", "")
-		}
-	}
+	ValidateStdEnsemblerNotConfiguredForNopExpEngine(sl, router.Ensembler, router.ExperimentEngine)
 }

--- a/api/turing/validation/validator.go
+++ b/api/turing/validation/validator.go
@@ -287,15 +287,15 @@ func validateConditionOrthogonality(
 	}
 }
 
-func ValidateStdEnsemblerNotConfiguredForNopExpEngine(
+func validateStdEnsemblerNotConfiguredForNopExpEngine(
 	sl validator.StructLevel,
 	ensembler *models.Ensembler,
 	experimentEngine *request.ExperimentEngineConfig,
 ) {
-	if ensembler != nil && ensembler.Type == models.EnsemblerStandardType {
-		if experimentEngine.Type == models.ExperimentEngineTypeNop {
-			sl.ReportError(experimentEngine.Type, "Type", "Type",
-				"should not be nop when a standard ensembler is configured", "")
+	if experimentEngine.Type == models.ExperimentEngineTypeNop {
+		if ensembler != nil && ensembler.Type == models.EnsemblerStandardType {
+			sl.ReportError(ensembler.Type, "Ensembler.Type", "Type",
+				"should not be standard if an nop experiment engine is configured", "")
 		}
 	}
 }
@@ -383,5 +383,5 @@ func validateRouterConfig(sl validator.StructLevel) {
 	}
 
 	// Validate that a non-nop experiment engine is used if a standard ensembler is set
-	ValidateStdEnsemblerNotConfiguredForNopExpEngine(sl, router.Ensembler, router.ExperimentEngine)
+	validateStdEnsemblerNotConfiguredForNopExpEngine(sl, router.Ensembler, router.ExperimentEngine)
 }

--- a/api/turing/validation/validator.go
+++ b/api/turing/validation/validator.go
@@ -368,4 +368,12 @@ func validateRouterConfig(sl validator.StructLevel) {
 		checkDanglingRoutes(sl, "Routes", router.Routes, allRuleRoutesSet)
 		validateConditionOrthogonality(sl, "TrafficRules", router.TrafficRules)
 	}
+
+	// Validate that a non-nop experiment engine is used if a standard ensembler is set
+	if router.Ensembler != nil && router.Ensembler.Type == models.EnsemblerStandardType {
+		if router.ExperimentEngine.Type == models.ExperimentEngineTypeNop {
+			sl.ReportError(router.ExperimentEngine.Type, "Type", "Type",
+				"should not be nop when a standard ensembler is configured", "")
+		}
+	}
 }

--- a/api/turing/validation/validator_test.go
+++ b/api/turing/validation/validator_test.go
@@ -336,6 +336,7 @@ func TestValidateTrafficRules(t *testing.T) {
 	defaultTrafficRule := &models.DefaultTrafficRule{
 		Routes: []string{routeAID, routeBID},
 	}
+	var dummyConfig json.RawMessage
 
 	suite := map[string]routerConfigTestCase{
 		"success": {
@@ -606,7 +607,10 @@ func TestValidateTrafficRules(t *testing.T) {
 				"Error:Field validation for 'default_route_id' failed on the 'should be set for chosen ensembler type' tag",
 		},
 		"failure | standard ensembler missing default route": {
-			routes:    models.Routes{routeA},
+			routes: models.Routes{routeA},
+			experimentEngine: &request.ExperimentEngineConfig{
+				Type: "custom",
+			},
 			ensembler: &models.Ensembler{Type: models.EnsemblerStandardType},
 			expectedError: "Key: 'RouterConfig.default_route_id' " +
 				"Error:Field validation for 'default_route_id' failed on the 'should be set for chosen ensembler type' tag",
@@ -955,7 +959,9 @@ func TestValidateTrafficRules(t *testing.T) {
 	for name, tt := range suite {
 		t.Run(name, func(t *testing.T) {
 			mockExperimentsService := &mocks.ExperimentsService{}
-			mockExperimentsService.On("ListEngines").Return([]manager.Engine{})
+			mockExperimentsService.On("ListEngines").Return([]manager.Engine{{Name: "custom"}})
+			mockExperimentsService.On("ValidateExperimentConfig", "custom", dummyConfig).
+				Return(nil)
 			validate, err := validation.NewValidator(mockExperimentsService)
 			require.NoError(t, err)
 

--- a/api/turing/validation/validator_test.go
+++ b/api/turing/validation/validator_test.go
@@ -1143,7 +1143,7 @@ func TestValidateStdEnsemblerNotConfiguredForNopExpEngine(t *testing.T) {
 				},
 			},
 		},
-		"failure | nop exp engine is configured with standard ensembler": {
+		"failure | standard ensembler is configured with nop exp engine": {
 			routes:         models.Routes{route},
 			defaultRouteID: &routeID,
 			ensembler: &models.Ensembler{
@@ -1152,9 +1152,9 @@ func TestValidateStdEnsemblerNotConfiguredForNopExpEngine(t *testing.T) {
 					RouteNamePath: "route-1",
 				},
 			},
-			expectedError: strings.Join([]string{"Key: 'RouterConfig.Type' ",
-				"Error:Field validation for 'Type' failed on the ",
-				"'should not be nop when a standard ensembler is configured' tag"}, ""),
+			expectedError: strings.Join([]string{"Key: 'RouterConfig.Ensembler.Type' ",
+				"Error:Field validation for 'Ensembler.Type' failed on the ",
+				"'should not be standard if an nop experiment engine is configured' tag"}, ""),
 		},
 	}
 	for name, tt := range suite {

--- a/api/turing/validation/validator_test.go
+++ b/api/turing/validation/validator_test.go
@@ -1153,7 +1153,8 @@ func TestValidateStdEnsemblerNotConfiguredForNopExpEngine(t *testing.T) {
 				},
 			},
 			expectedError: strings.Join([]string{"Key: 'RouterConfig.Type' ",
-				"Error:Field validation for 'Type' failed on the 'should not be nop when a standard ensembler is configured' tag"}, ""),
+				"Error:Field validation for 'Type' failed on the ",
+				"'should not be nop when a standard ensembler is configured' tag"}, ""),
 		},
 	}
 	for name, tt := range suite {


### PR DESCRIPTION
## Context 
As of present, Turing Routers created/updated with an `nop` experiment engine and a standard ensembler configured are not blocked by the Turing API server. Such router configurations are invalid because standard ensemblers are not meant to be utilised without an experiment engine. Hence, an appropriate error needs to be thrown whenever a user tries to create/edit routers with such a configuration. 

While the UI currently prevents such a scenario from occurring due to how it manages the router creation/edit workflow, an additional API validation check needs to be introduced so as to prevent such a scenario from occurring if users were to send requests to the API directly or via the SDK. This PR introduces such a check that throws an error if the aforementioned invalid configuration is used to create/update a Turing Router.

## Additional Modifications
- `api/go.mod` - Removal of explicit dependency on `github.com/go-playground/validator` in favour of `github.com/go-playground/validator/v10` (this package reappears as an indirect dependency but this needs to be removed from the `gojek/mlp` package for it to be completely removed)
