### PR TITLE
Add gke-gcloud-auth-plugin to dockerfile

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,3 +1,7 @@
+# Build stage 1: Download gke auth plugin
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine as gke-plugin-builder
+RUN gcloud components install gke-gcloud-auth-plugin --quiet
+
 # Build turing-api binary
 FROM golang:1.18-alpine as api-builder
 ARG API_BIN_NAME=turing-api
@@ -34,6 +38,7 @@ RUN addgroup -S ${TURING_USER_GROUP} \
 COPY --chown=${TURING_USER}:${TURING_USER_GROUP} --from=api-builder /app/bin/* /app
 COPY --chown=${TURING_USER}:${TURING_USER_GROUP} --from=api-builder /app/db-migrations /app/db-migrations
 COPY --chown=${TURING_USER}:${TURING_USER_GROUP} --from=api-builder /app/api/openapi.bundle.yaml /app/api/openapi.bundle.yaml
+COPY --chown=${TURING_USER}:${TURING_USER_GROUP} --from=gke-plugin-builder /google-cloud-sdk/bin/gke-gcloud-auth-plugin /usr/local/bin/gke-gcloud-auth-plugin
 
 USER ${TURING_USER}
 WORKDIR /app


### PR DESCRIPTION
### Motivation
* This PR adds `gke-gcloud-auth-plugin` to turing-api can access gke clusters without having to provide static credentials (ie client cert key, private key)
* This PR can be merged without affecting any existing logic

Reason:
* GKE clusters now support [authentication via plugin](https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke)
* `gke-gcloud-auth-plugin` is a go binary. Source code can be found [here](https://github.com/kubernetes/cloud-provider-gcp/tree/master/cmd/gke-gcloud-auth-plugin)
* There are 3 ways to install the plugin:
    1) via gcloud cli: `gcloud components install gke-gcloud-auth-plugin --quiet`
    2) via `go install <package>`
        * Howver, `go install <plugin>` returns this error
        ```sh
        ➜ go install github.com/kubernetes/cloud-provider-gcp/cmd/gke-gcloud-auth-plugin@929b1354f904a55d42389ae2a75021
        042e62e40f      
        go: downloading github.com/kubernetes/cloud-provider-gcp v0.0.0-20221223184326-929b1354f904
        go: github.com/kubernetes/cloud-provider-gcp/cmd/gke-gcloud-auth-plugin@929b1354f904a55d42389ae2a75021042e62e40
        f (in github.com/kubernetes/cloud-provider-gcp@v0.0.0-20221223184326-929b1354f904):
                The go.mod file for the module providing named packages contains one or
                more replace directives. It must not contain directives that would cause
                it to be interpreted differently than if it were the main module.
        ```
    3) via `apt-get install google-cloud-sdk-gke-gcloud-auth-plugin`
        * The go binary is built using go-alpine image, so this approach is not suitable as apt-get is only applicable to debian images

* Final approach uses `gcloud-sdk-cli:alpine` image as a build stage to download the `gke-gcloud-auth-plugin` binary, and copy the binary into the final image.
The only disadvantage of installing `gke-gcloud-auth-plugin` this way is that gcloud cli is not available. `gke-gcloud-auth-plugin` defaults to using gcloud to retrieve gcp access token. 
To get around this, the argument `--use_appliaction_default_credentials` needs to be supplied when environment config used in 
https://github.com/caraml-dev/turing/pull/303
```
gke-gcloud-auth-plugin --use_application_default_credentials
```
