### PR TITLE
Add plugin monitoring by pinging it async

### DIFF
--- a/api/turing/cluster/servicebuilder/router.go
+++ b/api/turing/cluster/servicebuilder/router.go
@@ -592,6 +592,8 @@ func buildFiberConfigMap(
 			if err != nil {
 				return nil, err
 			}
+
+			propsMap["experiment_engine_liveness_period_seconds"] = ver.ExperimentEngine.PluginConfig.LivenessPeriodSeconds
 		}
 		propsMap["experiment_engine_properties"] = expEngineProps
 	}

--- a/api/turing/config/config.go
+++ b/api/turing/config/config.go
@@ -262,7 +262,8 @@ type ExperimentEngineConfig struct {
 }
 
 type ExperimentEnginePluginConfig struct {
-	Image string `json:"image" validate:"required"`
+	Image                 string `json:"image" validate:"required"`
+	LivenessPeriodSeconds int    `json:"liveness_period_seconds" validate:"required"`
 }
 
 // RouterDefaults contains default configuration for routers deployed

--- a/api/turing/config/config_test.go
+++ b/api/turing/config/config_test.go
@@ -307,12 +307,14 @@ func TestLoad(t *testing.T) {
 					ExperimentEnginePlugins: map[string]*config.ExperimentEngineConfig{
 						"red": {
 							PluginConfig: &config.ExperimentEnginePluginConfig{
-								Image: "ghcr.io/myproject/red-exp-engine-plugin:v0.0.1",
+								Image:                 "ghcr.io/myproject/red-exp-engine-plugin:v0.0.1",
+								LivenessPeriodSeconds: 5,
 							},
 						},
 						"blue": {
 							PluginConfig: &config.ExperimentEnginePluginConfig{
-								Image: "ghcr.io/myproject/blue-exp-engine-plugin:latest",
+								Image:                 "ghcr.io/myproject/blue-exp-engine-plugin:latest",
+								LivenessPeriodSeconds: 10,
 							},
 							ServiceAccountKeyFilePath: &blueSvcAcctKeyFilePath,
 						},
@@ -426,12 +428,14 @@ func TestLoad(t *testing.T) {
 					ExperimentEnginePlugins: map[string]*config.ExperimentEngineConfig{
 						"red": {
 							PluginConfig: &config.ExperimentEnginePluginConfig{
-								Image: "ghcr.io/myproject/red-exp-engine-plugin:v0.0.1",
+								Image:                 "ghcr.io/myproject/red-exp-engine-plugin:v0.0.1",
+								LivenessPeriodSeconds: 5,
 							},
 						},
 						"blue": {
 							PluginConfig: &config.ExperimentEnginePluginConfig{
-								Image: "ghcr.io/myproject/blue-exp-engine-plugin:latest",
+								Image:                 "ghcr.io/myproject/blue-exp-engine-plugin:latest",
+								LivenessPeriodSeconds: 10,
 							},
 							ServiceAccountKeyFilePath: &blueSvcAcctKeyFilePath,
 						},

--- a/api/turing/config/testdata/config-2.yaml
+++ b/api/turing/config/testdata/config-2.yaml
@@ -16,9 +16,11 @@ RouterDefaults:
     red:
       PluginConfig:
         Image: ghcr.io/myproject/red-exp-engine-plugin:v0.0.1
+        LivenessPeriodSeconds: 5
     blue:
       PluginConfig:
         Image: ghcr.io/myproject/blue-exp-engine-plugin:latest
+        LivenessPeriodSeconds: 10
       ServiceAccountKeyFilePath: "/etc/plugins/blue/gcp_service_account/service-account.json"
   KafkaConfig:
     MaxMessageBytes: 1234567

--- a/api/turing/testdata/cluster/servicebuilder/router_configmap_exp_engine.yml
+++ b/api/turing/testdata/cluster/servicebuilder/router_configmap_exp_engine.yml
@@ -14,6 +14,7 @@ strategy:
   properties:
     default_route_id: control
     experiment_engine: exp-engine
+    experiment_engine_liveness_period_seconds: 5
     experiment_engine_properties:
       key-1: value-1
       plugin_binary: /app/plugins/exp-engine

--- a/api/turing/testdata/cluster/servicebuilder/router_version_success_experiment_engine.json
+++ b/api/turing/testdata/cluster/servicebuilder/router_version_success_experiment_engine.json
@@ -25,7 +25,8 @@
   "experiment_engine": {
     "type": "exp-engine",
     "plugin_config": {
-      "image": "ghcr.io/myproject/exp-engine-plugin:latest"
+      "image": "ghcr.io/myproject/exp-engine-plugin:latest",
+      "liveness_period_seconds": 5
     },
     "service_account_key_file_path": "/etc/plugins/blue/gcp_service_account/service-account.json",
     "config": {

--- a/engines/router/missionctl/experiment/experiment.go
+++ b/engines/router/missionctl/experiment/experiment.go
@@ -55,7 +55,6 @@ func startRPCPluginMonitoring(rpcEngineFactory *rpc.EngineFactory, livenessPerio
 	go func() {
 		for {
 			<-ticker.C
-			fmt.Println("test...")
 			err := rpcEngineFactory.Client.Ping()
 			if err != nil {
 				panic(fmt.Sprintf("Experiment engine plugin crashed: %s", err.Error()))

--- a/engines/router/missionctl/experiment/experiment.go
+++ b/engines/router/missionctl/experiment/experiment.go
@@ -56,12 +56,11 @@ func startRPCPluginMonitoring(rpcEngineFactory *rpc.EngineFactory, livenessPerio
 	ticker := time.NewTicker(time.Duration(livenessPeriodSeconds) * time.Second)
 	go func() {
 		for {
-			select {
-			case <-ticker.C:
-				err := rpcEngineFactory.Client.Ping()
-				if err != nil {
-					panic(fmt.Sprintf("Experiment engine plugin crashed: %s", err.Error()))
-				}
+			<-ticker.C
+			fmt.Println("test...")
+			err := rpcEngineFactory.Client.Ping()
+			if err != nil {
+				panic(fmt.Sprintf("Experiment engine plugin crashed: %s", err.Error()))
 			}
 		}
 	}()

--- a/engines/router/missionctl/experiment/experiment.go
+++ b/engines/router/missionctl/experiment/experiment.go
@@ -28,11 +28,9 @@ func NewExperimentRunner(
 		return nil, err
 	}
 
-	// If the experiment engine is an rpc engine with a liveness period configured
+	// If the experiment engine is an rpc engine
 	if rpcEngineFactory, ok := factory.(*rpc.EngineFactory); ok {
-		if livenessPeriodSeconds != 0 {
-			startRPCPluginMonitoring(rpcEngineFactory, livenessPeriodSeconds)
-		}
+		startRPCPluginMonitoring(rpcEngineFactory, livenessPeriodSeconds)
 	}
 
 	engine, err := factory.GetExperimentRunner()

--- a/engines/router/missionctl/experiment/experiment_test.go
+++ b/engines/router/missionctl/experiment/experiment_test.go
@@ -22,9 +22,10 @@ type testSuiteExperimentResponse struct {
 
 func TestNewExperimentRunner(t *testing.T) {
 	tests := map[string]struct {
-		engineName string
-		config     map[string]interface{}
-		wantErr    bool
+		engineName            string
+		config                map[string]interface{}
+		livenessPeriodSeconds int
+		wantErr               bool
 	}{
 		"nop | success": {
 			engineName: "nop",
@@ -37,7 +38,7 @@ func TestNewExperimentRunner(t *testing.T) {
 
 	for name, data := range tests {
 		t.Run(name, func(t *testing.T) {
-			_, err := NewExperimentRunner(data.engineName, data.config)
+			_, err := NewExperimentRunner(data.engineName, data.config, data.livenessPeriodSeconds)
 			if (err != nil) != data.wantErr {
 				t.Errorf("NewExperimentRunner() error= %v, wantErr %v", err, data.wantErr)
 			}

--- a/engines/router/missionctl/fiberapi/fan_in_test.go
+++ b/engines/router/missionctl/fiberapi/fan_in_test.go
@@ -107,7 +107,7 @@ func TestInitializeEnsemblingFanIn(t *testing.T) {
 			)
 			monkey.Patch(
 				experiment.NewExperimentRunner,
-				func(_ string, _ map[string]interface{}) (runner.ExperimentRunner, error) {
+				func(_ string, _ map[string]interface{}, _ int) (runner.ExperimentRunner, error) {
 					return nil, nil
 				},
 			)

--- a/engines/router/missionctl/fiberapi/routing_policies.go
+++ b/engines/router/missionctl/fiberapi/routing_policies.go
@@ -18,8 +18,9 @@ type routeSelPolicyCfg struct {
 }
 
 type expPolicyCfg struct {
-	ExpEngine      string                 `json:"experiment_engine,omitempty"`
-	ExpEngineProps map[string]interface{} `json:"experiment_engine_properties,omitempty"`
+	ExpEngine             string                 `json:"experiment_engine,omitempty"`
+	ExpEngineProps        map[string]interface{} `json:"experiment_engine_properties,omitempty"`
+	LivenessPeriodSeconds int                    `json:"experiment_engine_liveness_period_seconds,omitempty"`
 }
 
 // ****************************************************************************
@@ -96,6 +97,24 @@ func (exP experimentationPolicy) MarshalJSON() ([]byte, error) {
 	return jsonVal, nil
 }
 
+//func (exP experimentationPolicy) StartPluginMonitoring() {
+//	if exP.experimentEngineFactory != nil {
+//		ticker := time.NewTicker(time.Duration(exP.config.LivenessPeriodSeconds) * time.Second)
+//		go func() {
+//			for {
+//				select {
+//				case <-ticker.C:
+//					err := exP.experimentEngineFactory.Client.Ping()
+//					if err != nil {
+//						panic(fmt.Sprintf("Experiment engine plugin crashed: %s", err.Error()))
+//					}
+//				}
+//			}
+//		}()
+//	}
+//	return
+//}
+
 // newExperimentationPolicy is a creator function for experimentationPolicy
 func newExperimentationPolicy(properties json.RawMessage) (*experimentationPolicy, error) {
 	var expPolicy expPolicyCfg
@@ -107,7 +126,11 @@ func newExperimentationPolicy(properties json.RawMessage) (*experimentationPolic
 	}
 
 	// Initialize experiment policy
-	engine, err := experiment.NewExperimentRunner(expPolicy.ExpEngine, expPolicy.ExpEngineProps)
+	engine, err := experiment.NewExperimentRunner(
+		expPolicy.ExpEngine,
+		expPolicy.ExpEngineProps,
+		expPolicy.LivenessPeriodSeconds,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/engines/router/missionctl/fiberapi/routing_policies.go
+++ b/engines/router/missionctl/fiberapi/routing_policies.go
@@ -97,24 +97,6 @@ func (exP experimentationPolicy) MarshalJSON() ([]byte, error) {
 	return jsonVal, nil
 }
 
-//func (exP experimentationPolicy) StartPluginMonitoring() {
-//	if exP.experimentEngineFactory != nil {
-//		ticker := time.NewTicker(time.Duration(exP.config.LivenessPeriodSeconds) * time.Second)
-//		go func() {
-//			for {
-//				select {
-//				case <-ticker.C:
-//					err := exP.experimentEngineFactory.Client.Ping()
-//					if err != nil {
-//						panic(fmt.Sprintf("Experiment engine plugin crashed: %s", err.Error()))
-//					}
-//				}
-//			}
-//		}()
-//	}
-//	return
-//}
-
 // newExperimentationPolicy is a creator function for experimentationPolicy
 func newExperimentationPolicy(properties json.RawMessage) (*experimentationPolicy, error) {
 	var expPolicy expPolicyCfg

--- a/engines/router/missionctl/fiberapi/routing_strategy_test.go
+++ b/engines/router/missionctl/fiberapi/routing_strategy_test.go
@@ -112,7 +112,7 @@ func TestInitializeDefaultRoutingStrategy(t *testing.T) {
 			)
 			monkey.Patch(
 				experiment.NewExperimentRunner,
-				func(_ string, _ map[string]interface{}) (runner.ExperimentRunner, error) {
+				func(_ string, _ map[string]interface{}, _ int) (runner.ExperimentRunner, error) {
 					return nil, nil
 				},
 			)

--- a/infra/charts/turing/templates/_helpers.tpl
+++ b/infra/charts/turing/templates/_helpers.tpl
@@ -202,7 +202,7 @@ RouterDefaults:
 {{ if eq (toString $expEngine.type) "rpc-plugin" }}
       PluginConfig:
         Image: {{ $expEngine.rpcPlugin.image }}
-        LivenessPeriodSeconds: {{ $expEngine.rpcPlugin.livenessPeriodSeconds }}
+        LivenessPeriodSeconds: {{ $expEngine.rpcPlugin.livenessPeriodSeconds | default 10 }}
 {{ end }}
       ServiceAccountKeyFilePath: {{ $expEngine.serviceAccountKeyFilePath }}
 {{- end -}}

--- a/infra/charts/turing/templates/_helpers.tpl
+++ b/infra/charts/turing/templates/_helpers.tpl
@@ -202,6 +202,7 @@ RouterDefaults:
 {{ if eq (toString $expEngine.type) "rpc-plugin" }}
       PluginConfig:
         Image: {{ $expEngine.rpcPlugin.image }}
+        LivenessPeriodSeconds: {{ $expEngine.rpcPlugin.livenessPeriodSeconds }}
 {{ end }}
       ServiceAccountKeyFilePath: {{ $expEngine.serviceAccountKeyFilePath }}
 {{- end -}}

--- a/infra/e2e/turing.values.yaml
+++ b/infra/e2e/turing.values.yaml
@@ -18,7 +18,7 @@ turing:
     type: rpc-plugin
     rpcPlugin:
       image:  # Value will be set at install time using helm --set command
-      livenessPeriodSeconds: 10
+      livenessPeriodSeconds:  # Value is set as 10 by default but can be overwritten here
     options:
       engine:
         name: proprietary

--- a/infra/e2e/turing.values.yaml
+++ b/infra/e2e/turing.values.yaml
@@ -18,6 +18,7 @@ turing:
     type: rpc-plugin
     rpcPlugin:
       image:  # Value will be set at install time using helm --set command
+      livenessPeriodSeconds: 10
     options:
       engine:
         name: proprietary


### PR DESCRIPTION
## Context
Given the recent changes to [XP](https://github.com/caraml-dev/xp)'s experiment engine plugin to refactor its entire Treatment Service logic into a plugin, it has been observed that there would be an increased likelihood of the plugin failing due to its increased complexity. While this only affects XP's plugin, it has been decided that an experiment engine plugin failure, in general, should be handled differently by the Turing Router.

As of present, a Turing Router merely receives an error message when calling the `GetTreatmentForRequest` method of an experiment engine that has crashed, which conflates with regular error messages returned by the experiment engine plugin even when it is running normally. Hence, a separate way needs to be introduced to determine the health of the plugin, which this PR introduces through the use of `Ping()` in an asynchronous manner periodically.

Upon detecting that the plugin has crashed, the Router will be made to `panic()`. This was a conscious decision to ensure that any Routers with a faulty plugin that keeps crashing is bound to crash, as opposed to making the Router restart the plugin manually (asynchronously or not) which would allow the Router to either continue serving requests while relying on its fallback route or cause the Router's queue proxy to continue receiving requests while the Router attempts to restart and reconnect to the plugin. 

In both cases, there is reduced visibility of any actual fault of the plugin since the Router would repeatedly attempt to restart the plugin without giving any explicit alerts of a faulty plugin.

## Main Modifications
- `api/turing/cluster/servicebuilder/router.go` - Addition of a line to insert `LivenessPeriodSeconds`, the period at which a router should `Ping()` its plugin into a Router's configuration
- `api/turing/config/config.go` - Addition of the `LivenessPeriodSeconds` field to an experiment's plugin configuration
- `engines/router/missionctl/experiment/experiment.go` - Addition of a monitoring method to `Ping()` the experiment engine plugin repeatedly