### PR TITLE
Fix marshalling issue in config.Load()

### DIFF
--- a/api/turing/config/config.go
+++ b/api/turing/config/config.go
@@ -496,14 +496,21 @@ func Load(filepaths ...string) (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal config values: %s", err)
 	}
+	config, err = loadEnsemblingSvcConfig(config, v.AllSettings())
+	if err != nil {
+		return nil, fmt.Errorf("Failed to load ensemblingservicek8sconfig, err %s", err)
+	}
 
+	return config, nil
+}
+
+func loadEnsemblingSvcConfig(config *Config, v map[string]interface{}) (*Config, error) {
 	// NOTE: This section is added to parse any fields in EnsemblingServiceK8sConfig that does not
 	// have yaml tags.
 	// For example `certificate-authority-data` is not unmarshalled
 	// by vipers unmarshal method.
 
-	// convert back to byte string
-	clusterConfig, ok := v.AllSettings()["clusterconfig"]
+	clusterConfig, ok := v["clusterconfig"]
 	if !ok {
 		return config, nil
 	}
@@ -512,8 +519,9 @@ func Load(filepaths ...string) (*Config, error) {
 	if !ok {
 		return config, nil
 	}
+	// convert back to byte string
 	var byteForm []byte
-	byteForm, err = yaml.Marshal(ensemblingSvcK8sCfg)
+	byteForm, err := yaml.Marshal(ensemblingSvcK8sCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/api/turing/config/config_test.go
+++ b/api/turing/config/config_test.go
@@ -167,9 +167,7 @@ func TestLoad(t *testing.T) {
 				},
 				Sentry: sentry.Config{},
 				ClusterConfig: config.ClusterConfig{
-					InClusterConfig:            false,
-					EnvironmentConfigPath:      "",
-					EnsemblingServiceK8sConfig: &mlpcluster.K8sConfig{},
+					InClusterConfig: false,
 				},
 				AlertConfig: &config.AlertConfig{
 					GitLab: &config.GitlabConfig{

--- a/api/turing/config/config_test.go
+++ b/api/turing/config/config_test.go
@@ -167,7 +167,9 @@ func TestLoad(t *testing.T) {
 				},
 				Sentry: sentry.Config{},
 				ClusterConfig: config.ClusterConfig{
-					InClusterConfig: false,
+					InClusterConfig:            false,
+					EnvironmentConfigPath:      "",
+					EnsemblingServiceK8sConfig: &mlpcluster.K8sConfig{},
 				},
 				AlertConfig: &config.AlertConfig{
 					GitLab: &config.GitlabConfig{
@@ -243,6 +245,21 @@ func TestLoad(t *testing.T) {
 				ClusterConfig: config.ClusterConfig{
 					InClusterConfig:       false,
 					EnvironmentConfigPath: "path_to_env.yaml",
+					EnsemblingServiceK8sConfig: &mlpcluster.K8sConfig{
+						Name: "dev-server",
+						Cluster: &clientcmdapiv1.Cluster{
+							Server:                   "https://127.0.0.1",
+							CertificateAuthorityData: []byte("some_string"),
+						},
+						AuthInfo: &clientcmdapiv1.AuthInfo{
+							Exec: &clientcmdapiv1.ExecConfig{
+								APIVersion:         "some_api_version",
+								Command:            "some_command",
+								InteractiveMode:    clientcmdapiv1.IfAvailableExecInteractiveMode,
+								ProvideClusterInfo: true,
+							},
+						},
+					},
 				},
 				AlertConfig: &config.AlertConfig{
 					GitLab: &config.GitlabConfig{
@@ -346,6 +363,21 @@ func TestLoad(t *testing.T) {
 				ClusterConfig: config.ClusterConfig{
 					InClusterConfig:       false,
 					EnvironmentConfigPath: "path_to_env.yaml",
+					EnsemblingServiceK8sConfig: &mlpcluster.K8sConfig{
+						Name: "dev-server",
+						Cluster: &clientcmdapiv1.Cluster{
+							Server:                   "https://127.0.0.1",
+							CertificateAuthorityData: []byte("some_string"),
+						},
+						AuthInfo: &clientcmdapiv1.AuthInfo{
+							Exec: &clientcmdapiv1.ExecConfig{
+								APIVersion:         "some_api_version",
+								Command:            "some_command",
+								InteractiveMode:    clientcmdapiv1.IfAvailableExecInteractiveMode,
+								ProvideClusterInfo: true,
+							},
+						},
+					},
 				},
 				AlertConfig: &config.AlertConfig{
 					GitLab: &config.GitlabConfig{
@@ -469,6 +501,21 @@ func TestLoad(t *testing.T) {
 				ClusterConfig: config.ClusterConfig{
 					InClusterConfig:       false,
 					EnvironmentConfigPath: "env_var_path_to_env.yaml",
+					EnsemblingServiceK8sConfig: &mlpcluster.K8sConfig{
+						Name: "dev-server",
+						Cluster: &clientcmdapiv1.Cluster{
+							Server:                   "https://127.0.0.1",
+							CertificateAuthorityData: []byte("some_string"),
+						},
+						AuthInfo: &clientcmdapiv1.AuthInfo{
+							Exec: &clientcmdapiv1.ExecConfig{
+								APIVersion:         "some_api_version",
+								Command:            "some_command",
+								InteractiveMode:    clientcmdapiv1.IfAvailableExecInteractiveMode,
+								ProvideClusterInfo: true,
+							},
+						},
+					},
 				},
 				AlertConfig: &config.AlertConfig{
 					GitLab: &config.GitlabConfig{

--- a/api/turing/config/testdata/config-1.yaml
+++ b/api/turing/config/testdata/config-1.yaml
@@ -32,6 +32,18 @@ Sentry:
 ClusterConfig:
   InClusterConfig: false
   EnvironmentConfigPath: "path_to_env.yaml"
+  EnsemblingServiceK8sConfig:
+    name: dev-cluster
+    cluster:
+      server: https://127.0.0.1
+      certificate-authority-data: somestring
+    user:
+      exec:
+        apiVersion: someapiversion
+        command: some_comand
+        interactiveMode: IfAvailable
+        provideClusterInfo: true
+
 Experiment:
     qux:
       quxkey1: quxval1

--- a/api/turing/config/testdata/config-1.yaml
+++ b/api/turing/config/testdata/config-1.yaml
@@ -33,14 +33,15 @@ ClusterConfig:
   InClusterConfig: false
   EnvironmentConfigPath: "path_to_env.yaml"
   EnsemblingServiceK8sConfig:
-    name: dev-cluster
+    name: dev-server
     cluster:
       server: https://127.0.0.1
-      certificate-authority-data: somestring
+      certificate-authority-data: c29tZV9zdHJpbmc=
+
     user:
       exec:
-        apiVersion: someapiversion
-        command: some_comand
+        apiVersion: some_api_version
+        command: some_command
         interactiveMode: IfAvailable
         provideClusterInfo: true
 


### PR DESCRIPTION
### Summary
* This PR fixes a marshelling issue when reading in `ClusterConfig.EnsemblingServiceK8sConfig`, which results in some `k8sConfig.Cluster` fields not being read.
* This error was not detected in the e2e tests, as none of the routers created in e2e tests use the pyfunc ensemblers

### Modifications
`config.Load()` has been modified to further unmarshall `EnsemblingServiceK8sConfig` if it is present, using `"sigs.k8s.io/yaml"`. 
