### PR TITLE
Add tzdata dependency to Turing Router

### DIFF
--- a/engines/router/Dockerfile
+++ b/engines/router/Dockerfile
@@ -35,6 +35,7 @@ FROM alpine:latest
 ARG BIN_NAME=turing-router
 ENV BIN_NAME ${BIN_NAME}
 
+# This dependency installed is not used directly by the router but acts as a basic dependency for the experiment engine
 RUN apk update && apk add tzdata
 RUN addgroup -S app && adduser -S app -G app
 WORKDIR /app

--- a/engines/router/Dockerfile
+++ b/engines/router/Dockerfile
@@ -35,6 +35,7 @@ FROM alpine:latest
 ARG BIN_NAME=turing-router
 ENV BIN_NAME ${BIN_NAME}
 
+RUN apk update && apk add tzdata
 RUN addgroup -S app && adduser -S app -G app
 WORKDIR /app
 RUN chown -R app:app /app


### PR DESCRIPTION
## Context
This PR introduces the `tzdata` installation within the Turing Router image so as to allow it and other experiment engine plugins to utilise timezone related tools.

