### PR TITLE
Fix typo: Init cluster knative version help string

### DIFF
--- a/infra/cluster-init/init.sh
+++ b/infra/cluster-init/init.sh
@@ -20,7 +20,7 @@ function print_usage {
     echo "  Optional Environment Variables:"
     echo "    ISTIO_VERSION                              Istio version, default: 1.12.5."
     echo "    KNATIVE_VERSION                            Knative version, default: 1.7.4."
-    echo "    KNATIVE_ISTIO_VERSION                      Knative Istio version, default: 1.3.0."
+    echo "    KNATIVE_ISTIO_VERSION                      Knative Istio version, default: 1.7.1."
     echo "    KNATIVE_DOMAINS                            Knative domains that should be supported, comma seperated values"
     echo "    KNATIVE_REGISTRIES_SKIPPING_TAG_RESOLVING  Knative domains that should be supported, comma seperated values"
 }
@@ -56,7 +56,7 @@ function install_knative {
         -f knative-configmaps/config-features.yaml
 
     kubectl apply \
-        -f "https://github.com/knative-sandbox/net-istio/releases/download/knative-v${KNATIVE_ISTIO_VERSION:-1.3.0}/net-istio.yaml"
+        -f "https://github.com/knative-sandbox/net-istio/releases/download/knative-v${KNATIVE_ISTIO_VERSION:-1.7.1}/net-istio.yaml"
 
     local istio_apps=("net-istio-controller" "net-istio-webhook")
     for app in ${istio_apps[@]}; do

--- a/infra/cluster-init/init.sh
+++ b/infra/cluster-init/init.sh
@@ -19,7 +19,7 @@ function print_usage {
     echo
     echo "  Optional Environment Variables:"
     echo "    ISTIO_VERSION                              Istio version, default: 1.12.5."
-    echo "    KNATIVE_VERSION                            Knative version, default: 1.3.2."
+    echo "    KNATIVE_VERSION                            Knative version, default: 1.7.4."
     echo "    KNATIVE_ISTIO_VERSION                      Knative Istio version, default: 1.3.0."
     echo "    KNATIVE_DOMAINS                            Knative domains that should be supported, comma seperated values"
     echo "    KNATIVE_REGISTRIES_SKIPPING_TAG_RESOLVING  Knative domains that should be supported, comma seperated values"


### PR DESCRIPTION
Follow up from https://github.com/caraml-dev/turing/pull/305
- Fix typo in default Knative version in init cluster script's help string
- Update Knative Isio component version to `1.7.1` in init cluster script.