### PR TITLE
Change authentication method to use OIDC identity tokens

### DIFF
--- a/sdk/requirements.txt
+++ b/sdk/requirements.txt
@@ -12,4 +12,4 @@ protobuf>=3.0.0,<4.0.0dev
 python_dateutil>=2.5.3
 requests
 urllib3>=1.25.3
-git+https://github.com/deadlycoconuts/caraml-sdk.git@add_openid_connect_id_tokens_utils#egg=caraml-auth-google&subdirectory=packages/caraml-auth-google
+caraml-auth-google @ git+https://github.com/deadlycoconuts/caraml-sdk.git@add_openid_connect_id_tokens_utils#egg=caraml-auth-google&subdirectory=packages/caraml-auth-google

--- a/sdk/requirements.txt
+++ b/sdk/requirements.txt
@@ -1,7 +1,7 @@
 cloudpickle==2.0.0
 deprecation==2.1.0
 fire
-google-auth>=1.11.0
+google-auth>=2.16.2
 google-cloud-storage>=1.19.0
 mlflow>=1.2.0,<=1.23.0
 # Numpy >= v1.24.0 is incompatible with our pinned versions of mlflow due to the deprecation of several common numpy
@@ -12,3 +12,4 @@ protobuf>=3.0.0,<4.0.0dev
 python_dateutil>=2.5.3
 requests
 urllib3>=1.25.3
+git+https://github.com/deadlycoconuts/caraml-sdk.git@add_openid_connect_id_tokens_utils#egg=caraml-auth-google&subdirectory=packages/caraml-auth-google

--- a/sdk/requirements.txt
+++ b/sdk/requirements.txt
@@ -12,4 +12,4 @@ protobuf>=3.0.0,<4.0.0dev
 python_dateutil>=2.5.3
 requests
 urllib3>=1.25.3
-caraml-auth-google @ git+https://github.com/deadlycoconuts/caraml-sdk.git@add_openid_connect_id_tokens_utils#egg=caraml-auth-google&subdirectory=packages/caraml-auth-google
+caraml-auth-google @ git+https://github.com/caraml-dev/caraml-sdk.git@a662528#egg=caraml-auth-google&subdirectory=packages/caraml-auth-google

--- a/sdk/turing/session.py
+++ b/sdk/turing/session.py
@@ -59,7 +59,7 @@ class TuringSession:
             from google.auth.transport.requests import Request
             from google.auth.transport.urllib3 import urllib3, AuthorizedHttp
 
-            credentials = get_default_id_token_credentials(target_audience="turing-sdk.caraml")
+            credentials = get_default_id_token_credentials(target_audience="sdk.caraml")
             # Refresh credentials, in case it's coming from Compute Engine.
             # See: https://github.com/googleapis/google-auth-library-python/issues/1211
             credentials.refresh(Request())

--- a/sdk/turing/session.py
+++ b/sdk/turing/session.py
@@ -55,12 +55,11 @@ class TuringSession:
         self._api_client = ApiClient(config)
 
         if use_google_oauth:
-            import google.auth
+            from caraml_auth.id_token_credentials import get_default_id_token_credentials
             from google.auth.transport.requests import Request
             from google.auth.transport.urllib3 import urllib3, AuthorizedHttp
 
-            # Load default credentials
-            credentials, _ = google.auth.default(scopes=TuringSession.OAUTH_SCOPES)
+            credentials = get_default_id_token_credentials(target_audience="turing-sdk.caraml")
             # Refresh credentials, in case it's coming from Compute Engine.
             # See: https://github.com/googleapis/google-auth-library-python/issues/1211
             credentials.refresh(Request())


### PR DESCRIPTION
## Context
As of present, authentication is performed by the Merlin and Turing SDKs using Google OAuth 2.0 access tokens (generated after authentication with Google's OAuth server) that are added to the headers of requests sent to the Turing API server. These tokens are then used by an internal proxy which will validate the access token and then retrieve the user profile information from the Google API. 

However, in keeping with the move of the Google Identity Services client library from OAuth 2.0 access tokens to Google OpenID Connect (OIDC) identity tokens, we are similarly replacing the use of the former for the latter. These tokens generated would similarly be added to the headers of requests sent to the Turing API server to be validated internally. 

A utils module `caraml_auth` in the package `caraml-auth-google` has been created in the CaraML SDK [repository](https://github.com/caraml-dev/caraml-sdk) to provide this new method of authentication.

This PR serves to update the existing authentication method used by the Turing SDK.

## Changes
In `sdk/turing/session.py`, the Turing SDK will import and use the function `get_default_id_token_credentials` provided by the `caraml-auth-google` package:

```python
from caraml_auth.id_token_credentials import get_default_id_token_credentials

credentials = get_default_id_token_credentials(target_audience="turing-sdk.caraml")
credentials.refresh(Request())
```