### PR TITLE
Update caraml-auth-google version

### DIFF
--- a/sdk/requirements.txt
+++ b/sdk/requirements.txt
@@ -1,7 +1,6 @@
 cloudpickle==2.0.0
 deprecation==2.1.0
 fire
-google-auth>=2.16.2
 google-cloud-storage>=1.19.0
 mlflow>=1.2.0,<=1.23.0
 # Numpy >= v1.24.0 is incompatible with our pinned versions of mlflow due to the deprecation of several common numpy

--- a/sdk/requirements.txt
+++ b/sdk/requirements.txt
@@ -12,4 +12,4 @@ protobuf>=3.0.0,<4.0.0dev
 python_dateutil>=2.5.3
 requests
 urllib3>=1.25.3
-caraml-auth-google @ git+https://github.com/caraml-dev/caraml-sdk.git@a662528#egg=caraml-auth-google&subdirectory=packages/caraml-auth-google
+caraml-auth-google==0.0.0.post3


### PR DESCRIPTION
## Context
The new version of the Turing SDK which incorporates changes to authenticate the user with OpenID Connect tokens did not manage to be pushed successfully to the PyPI repository because it was using a Git dependency on `caraml-auth-google`, which Git dependencies are not allowed by PyPI. 

Since then, `caraml-auth-google` has been finally released directly to PyPI, paving way for the Turing SDK to update its dependency on it to utilise the released version directly. This PR updates that version directly in the `requirements.txt` file.