### PR TITLE
Remove oauth scope warning and redundant oauth scope

### DIFF
--- a/sdk/requirements.txt
+++ b/sdk/requirements.txt
@@ -11,4 +11,4 @@ protobuf>=3.0.0,<4.0.0dev
 python_dateutil>=2.5.3
 requests
 urllib3>=1.25.3
-caraml-auth-google==0.0.0.post3
+caraml-auth-google==0.0.0.post4

--- a/sdk/turing/session.py
+++ b/sdk/turing/session.py
@@ -39,8 +39,6 @@ class TuringSession:
     Session object for interacting with Turing back-end
     """
 
-    OAUTH_SCOPES = ["https://www.googleapis.com/auth/userinfo.email"]
-
     def __init__(
         self, host: str, project_name: str = None, use_google_oauth: bool = True
     ):


### PR DESCRIPTION
## Context
When the Turing SDK is used to authenticate a user with a user account, the warning `Not all requested scopes were granted by the authorization server, missing scopes email.` gets thrown because the scope specified for the email field was stated as `email` instead of `https://www.googleapis.com/auth/userinfo.email` (see https://developers.google.com/identity/protocols/oauth2/scopes#oauth2 for more info).

The relevant change has already been made in https://github.com/caraml-dev/caraml-sdk/pull/3, and this PR makes a change to the version of `caraml-auth-google` to incorporate those changes. The unused constant `OAUTH_SCOPES` has also been removed from the SDK in the process.

Thanks @ariefrahmansyah for catching this!