### PR TITLE
Bugfix: Fix pyfunc ensembler undeployment bug

### DIFF
--- a/api/e2e/test/config/config.go
+++ b/api/e2e/test/config/config.go
@@ -92,10 +92,7 @@ func (k *K8sConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 	// use sigyaml.Unmarshal to convert to json object then unmarshal
-	if err := sigyaml.Unmarshal(byteForm, k); err != nil {
-		return err
-	}
-	return nil
+	return sigyaml.Unmarshal(byteForm, k)
 }
 
 type ClusterConfig struct {

--- a/api/e2e/test/router_e2e_test.go
+++ b/api/e2e/test/router_e2e_test.go
@@ -184,7 +184,6 @@ var _ = DeployedRouterContext("testdata/create_router_nop_logger_proprietary_exp
 
 							Eventually(func(g Gomega) {
 								router = api.GetRouter(apiE, routerCtx.ProjectID, routerCtx.ID)
-								// TODO: Why is it pending? - g.Expect(router.Value("status").Raw()).To(Equal(api.Status.Pending))
 								g.Expect(router.Value("status").Raw()).To(Equal(api.Status.Undeployed))
 							}, arbitraryUpdateIntervals...).Should(Succeed())
 						})

--- a/api/turing/api/alerts_api.go
+++ b/api/turing/api/alerts_api.go
@@ -59,7 +59,7 @@ func (c AlertsController) CreateAlert(r *http.Request, vars RequestVars, body in
 	return Ok(created)
 }
 
-func (c AlertsController) ListAlerts(r *http.Request, vars RequestVars, _ interface{}) *Response {
+func (c AlertsController) ListAlerts(_ *http.Request, vars RequestVars, _ interface{}) *Response {
 	if c.AlertService == nil {
 		return BadRequest(ErrAlertDisabled.Error(), "")
 	}
@@ -79,7 +79,7 @@ func (c AlertsController) ListAlerts(r *http.Request, vars RequestVars, _ interf
 	return Ok(alerts)
 }
 
-func (c AlertsController) GetAlert(r *http.Request, vars RequestVars, _ interface{}) *Response {
+func (c AlertsController) GetAlert(_ *http.Request, vars RequestVars, _ interface{}) *Response {
 	if c.AlertService == nil {
 		return BadRequest(ErrAlertDisabled.Error(), "")
 	}

--- a/api/turing/api/ensemblers_api.go
+++ b/api/turing/api/ensemblers_api.go
@@ -16,7 +16,7 @@ type EnsemblersController struct {
 }
 
 func (c EnsemblersController) ListEnsemblers(
-	r *http.Request,
+	_ *http.Request,
 	vars RequestVars,
 	_ interface{},
 ) *Response {

--- a/api/turing/api/ensembling_job_api.go
+++ b/api/turing/api/ensembling_job_api.go
@@ -18,7 +18,7 @@ type EnsemblingJobController struct {
 // Create is a HTTP Post Method that creates an Ensembling job.
 // This method will only return the acceptance/rejection of the job rather than the actual result of the job.
 func (c EnsemblingJobController) Create(
-	r *http.Request,
+	_ *http.Request,
 	vars RequestVars,
 	body interface{},
 ) *Response {

--- a/api/turing/api/experiments_api.go
+++ b/api/turing/api/experiments_api.go
@@ -22,7 +22,7 @@ func (c ExperimentsController) ListExperimentEngines(
 
 // ListExperimentEngineClients returns a list of clients on the given experiment engine
 func (c ExperimentsController) ListExperimentEngineClients(
-	r *http.Request,
+	_ *http.Request,
 	vars RequestVars,
 	_ interface{},
 ) *Response {
@@ -42,7 +42,7 @@ func (c ExperimentsController) ListExperimentEngineClients(
 // ListExperimentEngineExperiments returns a list of experiments on the given experiment engine,
 // optionally tied to the given client id
 func (c ExperimentsController) ListExperimentEngineExperiments(
-	r *http.Request,
+	_ *http.Request,
 	vars RequestVars,
 	_ interface{},
 ) *Response {
@@ -64,7 +64,7 @@ func (c ExperimentsController) ListExperimentEngineExperiments(
 
 // ListExperimentEngineVariables returns a list of variables for the given client and/or experiments
 func (c ExperimentsController) ListExperimentEngineVariables(
-	r *http.Request,
+	_ *http.Request,
 	vars RequestVars,
 	_ interface{},
 ) *Response {

--- a/api/turing/api/router_versions_api.go
+++ b/api/turing/api/router_versions_api.go
@@ -16,7 +16,7 @@ type RouterVersionsController struct {
 
 // ListRouterVersions lists the router versions of the provided router.
 func (c RouterVersionsController) ListRouterVersions(
-	r *http.Request,
+	_ *http.Request,
 	vars RequestVars, _ interface{},
 ) *Response {
 	// Parse request vars
@@ -38,7 +38,7 @@ func (c RouterVersionsController) ListRouterVersions(
 // CreateRouterVersion creates a router version from the provided configuration. If no router exists
 // within the provided project with the provided id, this method will throw an error.
 // If the update is valid, a new RouterVersion will be created but NOT deployed.
-func (c RouterVersionsController) CreateRouterVersion(r *http.Request, vars RequestVars, body interface{}) *Response {
+func (c RouterVersionsController) CreateRouterVersion(_ *http.Request, vars RequestVars, body interface{}) *Response {
 	// Parse request vars
 	var errResp *Response
 	var router *models.Router
@@ -81,7 +81,7 @@ func (c RouterVersionsController) CreateRouterVersion(r *http.Request, vars Requ
 
 // GetRouterVersion gets the router version for the provided router id and version number.
 func (c RouterVersionsController) GetRouterVersion(
-	r *http.Request,
+	_ *http.Request,
 	vars RequestVars, _ interface{},
 ) *Response {
 	// Parse request vars
@@ -97,7 +97,7 @@ func (c RouterVersionsController) GetRouterVersion(
 
 // DeleteRouterVersion deletes the config for the given version number.
 func (c RouterVersionsController) DeleteRouterVersion(
-	r *http.Request,
+	_ *http.Request,
 	vars RequestVars,
 	_ interface{},
 ) *Response {
@@ -132,9 +132,9 @@ func (c RouterVersionsController) DeleteRouterVersion(
 
 // DeployRouterVersion deploys the given router version into the associated kubernetes cluster
 func (c RouterVersionsController) DeployRouterVersion(
-	r *http.Request,
+	_ *http.Request,
 	vars RequestVars,
-	body interface{},
+	_ interface{},
 ) *Response {
 	// Parse request vars
 	var errResp *Response

--- a/api/turing/api/routers_api.go
+++ b/api/turing/api/routers_api.go
@@ -20,7 +20,7 @@ type RoutersController struct {
 // ListRouters lists all routers configured in the provided project.
 // If none are found, an error will be thrown.
 func (c RoutersController) ListRouters(
-	r *http.Request,
+	_ *http.Request,
 	vars RequestVars, _ interface{},
 ) *Response {
 	// Parse input
@@ -41,7 +41,7 @@ func (c RoutersController) ListRouters(
 
 // GetRouter gets a router matching the provided routerID.
 func (c RoutersController) GetRouter(
-	r *http.Request,
+	_ *http.Request,
 	vars RequestVars, _ interface{},
 ) *Response {
 	// Parse input
@@ -59,7 +59,7 @@ func (c RoutersController) GetRouter(
 // a router within the provided project with the same name, this method will throw an error.
 // If not, a new Router and associated RouterVersion will be created and deployed.
 func (c RoutersController) CreateRouter(
-	r *http.Request,
+	_ *http.Request,
 	vars RequestVars,
 	body interface{},
 ) *Response {
@@ -134,7 +134,7 @@ func (c RoutersController) CreateRouter(
 // UpdateRouter updates a router from the provided configuration. If no router exists
 // within the provided project with the provided id, this method will throw an error.
 // If the update is valid, a new RouterVersion will be created and deployed.
-func (c RoutersController) UpdateRouter(r *http.Request, vars RequestVars, body interface{}) *Response {
+func (c RoutersController) UpdateRouter(_ *http.Request, vars RequestVars, body interface{}) *Response {
 	// Parse request vars
 	var errResp *Response
 	var project *mlp.Project
@@ -196,7 +196,7 @@ func (c RoutersController) UpdateRouter(r *http.Request, vars RequestVars, body 
 
 // DeleteRouter deletes a router and all its associated versions.
 func (c RoutersController) DeleteRouter(
-	r *http.Request,
+	_ *http.Request,
 	vars RequestVars,
 	_ interface{},
 ) *Response {
@@ -231,9 +231,9 @@ func (c RoutersController) DeleteRouter(
 // DeployRouter deploys the current version of the given router into the associated
 // kubernetes cluster. If there is no current version, an error is returned.
 func (c RoutersController) DeployRouter(
-	r *http.Request,
+	_ *http.Request,
 	vars RequestVars,
-	body interface{},
+	_ interface{},
 ) *Response {
 	// Parse request vars
 	var errResp *Response
@@ -284,9 +284,9 @@ func (c RoutersController) DeployRouter(
 
 // UndeployRouter deletes the given router specs from the associated kubernetes cluster
 func (c RoutersController) UndeployRouter(
-	r *http.Request,
+	_ *http.Request,
 	vars RequestVars,
-	body interface{},
+	_ interface{},
 ) *Response {
 	// Parse request vars
 	var errResp *Response
@@ -308,9 +308,9 @@ func (c RoutersController) UndeployRouter(
 	return Ok(map[string]int{"router_id": int(router.ID)})
 }
 
-func (c RoutersController) ListRouterEvents(r *http.Request,
+func (c RoutersController) ListRouterEvents(_ *http.Request,
 	vars RequestVars,
-	body interface{},
+	_ interface{},
 ) *Response {
 	// Parse request vars
 	var errResp *Response

--- a/api/turing/cluster/servicebuilder/router.go
+++ b/api/turing/cluster/servicebuilder/router.go
@@ -123,7 +123,7 @@ func (sb *clusterSvcBuilder) NewRouterService(
 
 	// Build env vars
 	envs, err := sb.buildRouterEnvs(namespace, envType, routerDefaults,
-		sentryEnabled, sentryDSN, secretName, routerVersion)
+		sentryEnabled, sentryDSN, routerVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -207,7 +207,6 @@ func (sb *clusterSvcBuilder) buildRouterEnvs(
 	routerDefaults *config.RouterDefaults,
 	sentryEnabled bool,
 	sentryDSN string,
-	secretName string,
 	ver *models.RouterVersion,
 ) ([]corev1.EnvVar, error) {
 	// Add app name, router timeout, jaeger collector

--- a/api/turing/cluster/servicebuilder/router.go
+++ b/api/turing/cluster/servicebuilder/router.go
@@ -166,7 +166,6 @@ func (sb *clusterSvcBuilder) NewRouterService(
 func (sb *clusterSvcBuilder) NewRouterEndpoint(
 	routerVersion *models.RouterVersion,
 	project *mlp.Project,
-	envType string,
 	versionEndpoint string,
 ) (*cluster.VirtualService, error) {
 	labels := buildLabels(project, routerVersion.Router)

--- a/api/turing/cluster/servicebuilder/router_test.go
+++ b/api/turing/cluster/servicebuilder/router_test.go
@@ -1193,7 +1193,6 @@ func TestBuildRouterEnvsResultLogger(t *testing.T) {
 				tt.args.routerDefaults,
 				tt.args.sentryEnabled,
 				tt.args.sentryDSN,
-				tt.args.secretName,
 				tt.args.ver)
 			assert.Equal(t, tt.want, got)
 		})

--- a/api/turing/cluster/servicebuilder/router_test.go
+++ b/api/turing/cluster/servicebuilder/router_test.go
@@ -1058,7 +1058,7 @@ func TestNewRouterEndpoint(t *testing.T) {
 		MatchURIPrefixes: defaultMatchURIPrefixes,
 	}
 
-	got, err := sb.NewRouterEndpoint(&routerVersion, project, "test-env", versionEndpoint)
+	got, err := sb.NewRouterEndpoint(&routerVersion, project, versionEndpoint)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, got)
 }

--- a/api/turing/cluster/servicebuilder/service_builder.go
+++ b/api/turing/cluster/servicebuilder/service_builder.go
@@ -60,7 +60,6 @@ type ClusterServiceBuilder interface {
 	NewEnricherService(
 		ver *models.RouterVersion,
 		project *mlp.Project,
-		envType string,
 		secretName string,
 		knativeQueueProxyResourcePercentage int,
 		userContainerLimitRequestFactor float64,
@@ -135,7 +134,6 @@ func NewClusterServiceBuilder(
 func (sb *clusterSvcBuilder) NewEnricherService(
 	routerVersion *models.RouterVersion,
 	project *mlp.Project,
-	envType string,
 	secretName string,
 	knativeQueueProxyResourcePercentage int,
 	userContainerLimitRequestFactor float64,

--- a/api/turing/cluster/servicebuilder/service_builder.go
+++ b/api/turing/cluster/servicebuilder/service_builder.go
@@ -94,7 +94,6 @@ type ClusterServiceBuilder interface {
 	NewRouterEndpoint(
 		routerVersion *models.RouterVersion,
 		project *mlp.Project,
-		envType string,
 		versionEndpoint string,
 	) (*cluster.VirtualService, error)
 	NewSecret(

--- a/api/turing/cluster/servicebuilder/service_builder.go
+++ b/api/turing/cluster/servicebuilder/service_builder.go
@@ -67,7 +67,6 @@ type ClusterServiceBuilder interface {
 	NewEnsemblerService(
 		ver *models.RouterVersion,
 		project *mlp.Project,
-		envType string,
 		secretName string,
 		knativeQueueProxyResourcePercentage int,
 		userContainerLimitRequestFactor float64,
@@ -218,7 +217,6 @@ func (sb *clusterSvcBuilder) NewEnricherService(
 func (sb *clusterSvcBuilder) NewEnsemblerService(
 	routerVersion *models.RouterVersion,
 	project *mlp.Project,
-	envType string,
 	secretName string,
 	knativeQueueProxyResourcePercentage int,
 	userContainerLimitRequestFactor float64,

--- a/api/turing/cluster/servicebuilder/service_builder_test.go
+++ b/api/turing/cluster/servicebuilder/service_builder_test.go
@@ -220,7 +220,7 @@ func TestNewEnsemblerService(t *testing.T) {
 				Stream: "test-stream",
 				Team:   "test-team",
 			}
-			svc, err := sb.NewEnsemblerService(routerVersion, project, "test-env", "secret", 20, 1.5)
+			svc, err := sb.NewEnsemblerService(routerVersion, project, "secret", 20, 1.5)
 			if data.err == "" {
 				assert.NoError(t, err)
 				assert.Equal(t, data.expected, svc)

--- a/api/turing/cluster/servicebuilder/service_builder_test.go
+++ b/api/turing/cluster/servicebuilder/service_builder_test.go
@@ -104,7 +104,7 @@ func TestNewEnricherService(t *testing.T) {
 				Stream: "test-stream",
 				Team:   "test-team",
 			}
-			svc, err := sb.NewEnricherService(routerVersion, project, "test-env", "secret", 10, 1.5)
+			svc, err := sb.NewEnricherService(routerVersion, project, "secret", 10, 1.5)
 			if data.err == "" {
 				assert.NoError(t, err)
 				assert.Equal(t, data.expected, svc)

--- a/api/turing/service/router_deployment_service.go
+++ b/api/turing/service/router_deployment_service.go
@@ -206,7 +206,7 @@ func (ds *deploymentService) DeployRouterVersion(
 
 	// Deploy or update the virtual service
 	eventsCh.Write(models.NewInfoEvent(models.EventStageUpdatingEndpoint, "updating router endpoint"))
-	routerEndpoint, err := ds.svcBuilder.NewRouterEndpoint(routerVersion, project, ds.environmentType, endpoint)
+	routerEndpoint, err := ds.svcBuilder.NewRouterEndpoint(routerVersion, project, endpoint)
 	if err != nil {
 		eventsCh.Write(models.NewErrorEvent(
 			models.EventStageUpdatingEndpoint, "failed to update router endpoint: %s", err.Error()))

--- a/api/turing/service/router_deployment_service.go
+++ b/api/turing/service/router_deployment_service.go
@@ -453,7 +453,6 @@ func (ds *deploymentService) buildEnsemblerServiceImage(
 		Endpoint:          PyFuncEnsemblerServiceEndpoint,
 		Port:              PyFuncEnsemblerServicePort,
 		Env:               routerVersion.Ensembler.PyfuncConfig.Env,
-		ServiceAccount:    "",
 	}
 
 	return nil

--- a/api/turing/service/router_deployment_service.go
+++ b/api/turing/service/router_deployment_service.go
@@ -367,7 +367,6 @@ func (ds *deploymentService) createServices(
 		ensemblerSvc, err := ds.svcBuilder.NewEnsemblerService(
 			routerVersion,
 			project,
-			envType,
 			secretName,
 			knativeQueueProxyResourcePercentage,
 			userContainerLimitRequestFactor,

--- a/api/turing/service/router_deployment_service.go
+++ b/api/turing/service/router_deployment_service.go
@@ -352,7 +352,6 @@ func (ds *deploymentService) createServices(
 		enricherSvc, err := ds.svcBuilder.NewEnricherService(
 			routerVersion,
 			project,
-			envType,
 			secretName,
 			knativeQueueProxyResourcePercentage,
 			userContainerLimitRequestFactor,

--- a/api/turing/service/router_deployment_service_test.go
+++ b/api/turing/service/router_deployment_service_test.go
@@ -36,7 +36,6 @@ type mockClusterServiceBuilder struct {
 func (msb *mockClusterServiceBuilder) NewRouterEndpoint(
 	routerVersion *models.RouterVersion,
 	project *mlp.Project,
-	envType string,
 	versionEndpoint string,
 ) (*cluster.VirtualService, error) {
 	return &cluster.VirtualService{

--- a/api/turing/service/router_deployment_service_test.go
+++ b/api/turing/service/router_deployment_service_test.go
@@ -34,9 +34,9 @@ type mockClusterServiceBuilder struct {
 }
 
 func (msb *mockClusterServiceBuilder) NewRouterEndpoint(
-	routerVersion *models.RouterVersion,
-	project *mlp.Project,
-	versionEndpoint string,
+	_ *models.RouterVersion,
+	_ *mlp.Project,
+	_ string,
 ) (*cluster.VirtualService, error) {
 	return &cluster.VirtualService{
 		Name:      "test-svc-turing-router",
@@ -94,7 +94,7 @@ func (msb *mockClusterServiceBuilder) NewEnricherService(
 func (msb *mockClusterServiceBuilder) NewEnsemblerService(
 	rv *models.RouterVersion,
 	project *mlp.Project,
-	secretName string,
+	_ string,
 	queueProxyResourcePercentage int,
 	userContainerLimitRequestFactor float64,
 ) (*cluster.KnativeService, error) {
@@ -118,7 +118,7 @@ func (msb *mockClusterServiceBuilder) NewRouterService(
 	rv *models.RouterVersion,
 	project *mlp.Project,
 	envType string,
-	secretName string,
+	_ string,
 	expConfig json.RawMessage,
 	routerDefaults *config.RouterDefaults,
 	sentryEnabled bool,
@@ -156,8 +156,8 @@ func (msb *mockClusterServiceBuilder) NewRouterService(
 func (msb *mockClusterServiceBuilder) NewFluentdService(
 	rv *models.RouterVersion,
 	project *mlp.Project,
-	serviceAccountSecretName string,
-	cfg *config.FluentdConfig,
+	_ string,
+	_ *config.FluentdConfig,
 ) *cluster.KubernetesService {
 	return &cluster.KubernetesService{
 		BaseService: &cluster.BaseService{
@@ -168,7 +168,7 @@ func (msb *mockClusterServiceBuilder) NewFluentdService(
 	}
 }
 
-func (msb *mockClusterServiceBuilder) GetRouterServiceName(ver *models.RouterVersion) string {
+func (msb *mockClusterServiceBuilder) GetRouterServiceName(_ *models.RouterVersion) string {
 	return "test-router-svc"
 }
 

--- a/api/turing/service/router_deployment_service_test.go
+++ b/api/turing/service/router_deployment_service_test.go
@@ -471,6 +471,5 @@ func TestBuildEnsemblerServiceImage(t *testing.T) {
 		Endpoint:          "/ensemble",
 		Port:              8083,
 		Env:               routerVersion.Ensembler.PyfuncConfig.Env,
-		ServiceAccount:    "",
 	})
 }

--- a/api/turing/service/router_deployment_service_test.go
+++ b/api/turing/service/router_deployment_service_test.go
@@ -82,9 +82,6 @@ func (msb *mockClusterServiceBuilder) NewEnricherService(
 		BaseService: &cluster.BaseService{
 			Name:      fmt.Sprintf("%s-enricher-%d", rv.Router.Name, rv.Version),
 			Namespace: project.Name,
-			Labels: map[string]string{
-				"env": "staging",
-			},
 		},
 		QueueProxyResourcePercentage:    queueProxyResourcePercentage,
 		UserContainerLimitRequestFactor: userContainerLimitRequestFactor,
@@ -105,9 +102,6 @@ func (msb *mockClusterServiceBuilder) NewEnsemblerService(
 		BaseService: &cluster.BaseService{
 			Name:      fmt.Sprintf("%s-ensembler-%d", rv.Router.Name, rv.Version),
 			Namespace: project.Name,
-			Labels: map[string]string{
-				"env": "staging",
-			},
 		},
 		QueueProxyResourcePercentage:    queueProxyResourcePercentage,
 		UserContainerLimitRequestFactor: userContainerLimitRequestFactor,
@@ -139,9 +133,6 @@ func (msb *mockClusterServiceBuilder) NewRouterService(
 				{Name: "ENVIRONMENT", Value: envType},
 				{Name: "SENTRY_ENABLED", Value: strconv.FormatBool(sentryEnabled)},
 				{Name: "SENTRY_DSN", Value: sentryDSN},
-			},
-			Labels: map[string]string{
-				"env": envType,
 			},
 			ConfigMap: &cluster.ConfigMap{
 				Name: fmt.Sprintf("%s-fiber-config-%d", rv.Router.Name, rv.Version),
@@ -268,9 +259,6 @@ func TestDeployEndpoint(t *testing.T) {
 		BaseService: &cluster.BaseService{
 			Name:      fmt.Sprintf("%s-enricher-%d", routerVersion.Router.Name, routerVersion.Version),
 			Namespace: testNamespace,
-			Labels: map[string]string{
-				"env": envType,
-			},
 		},
 		QueueProxyResourcePercentage:    20,
 		UserContainerLimitRequestFactor: 1.75,
@@ -279,9 +267,6 @@ func TestDeployEndpoint(t *testing.T) {
 		BaseService: &cluster.BaseService{
 			Name:      fmt.Sprintf("%s-ensembler-%d", routerVersion.Router.Name, routerVersion.Version),
 			Namespace: testNamespace,
-			Labels: map[string]string{
-				"env": envType,
-			},
 		},
 		QueueProxyResourcePercentage:    20,
 		UserContainerLimitRequestFactor: 1.75,
@@ -298,9 +283,6 @@ func TestDeployEndpoint(t *testing.T) {
 				{Name: "ENVIRONMENT", Value: envType},
 				{Name: "SENTRY_ENABLED", Value: "true"},
 				{Name: "SENTRY_DSN", Value: "test:dsn"},
-			},
-			Labels: map[string]string{
-				"env": envType,
 			},
 			ConfigMap: &cluster.ConfigMap{
 				Name: fmt.Sprintf("%s-fiber-config-%d",

--- a/api/turing/service/router_deployment_service_test.go
+++ b/api/turing/service/router_deployment_service_test.go
@@ -71,8 +71,7 @@ func (msb *mockClusterServiceBuilder) NewSecret(
 func (msb *mockClusterServiceBuilder) NewEnricherService(
 	rv *models.RouterVersion,
 	project *mlp.Project,
-	envType string,
-	secretName string,
+	_ string,
 	queueProxyResourcePercentage int,
 	userContainerLimitRequestFactor float64,
 ) (*cluster.KnativeService, error) {
@@ -84,7 +83,7 @@ func (msb *mockClusterServiceBuilder) NewEnricherService(
 			Name:      fmt.Sprintf("%s-enricher-%d", rv.Router.Name, rv.Version),
 			Namespace: project.Name,
 			Labels: map[string]string{
-				"env": envType,
+				"env": "staging",
 			},
 		},
 		QueueProxyResourcePercentage:    queueProxyResourcePercentage,

--- a/api/turing/service/router_deployment_service_test.go
+++ b/api/turing/service/router_deployment_service_test.go
@@ -94,7 +94,6 @@ func (msb *mockClusterServiceBuilder) NewEnricherService(
 func (msb *mockClusterServiceBuilder) NewEnsemblerService(
 	rv *models.RouterVersion,
 	project *mlp.Project,
-	envType string,
 	secretName string,
 	queueProxyResourcePercentage int,
 	userContainerLimitRequestFactor float64,
@@ -107,7 +106,7 @@ func (msb *mockClusterServiceBuilder) NewEnsemblerService(
 			Name:      fmt.Sprintf("%s-ensembler-%d", rv.Router.Name, rv.Version),
 			Namespace: project.Name,
 			Labels: map[string]string{
-				"env": envType,
+				"env": "staging",
 			},
 		},
 		QueueProxyResourcePercentage:    queueProxyResourcePercentage,

--- a/api/turing/service/router_version_service.go
+++ b/api/turing/service/router_version_service.go
@@ -133,6 +133,17 @@ func (service *routerVersionsService) Save(routerVersion *models.RouterVersion) 
 		// We don't allow ensembler and enricher updates. Changes to those elements
 		// will always result in a new version being spawned.
 		err = tx.Save(routerVersion).Error
+		if err != nil {
+			return nil, err
+		}
+		err = tx.Save(routerVersion.Enricher).Error
+		if err != nil {
+			return nil, err
+		}
+		err = tx.Save(routerVersion.Ensembler).Error
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if err != nil {

--- a/api/turing/service/router_version_service.go
+++ b/api/turing/service/router_version_service.go
@@ -130,19 +130,25 @@ func (service *routerVersionsService) Save(routerVersion *models.RouterVersion) 
 		}
 		err = tx.Create(routerVersion).Error
 	} else {
-		// We don't allow ensembler and enricher updates. Changes to those elements
-		// will always result in a new version being spawned.
+		// We don't allow ensembler and enricher updates without an update to the entire router version.
+		// Changes to those elements will always result in a new version being spawned.
 		err = tx.Save(routerVersion).Error
 		if err != nil {
 			return nil, err
 		}
-		err = tx.Save(routerVersion.Enricher).Error
-		if err != nil {
-			return nil, err
+		// These steps below are meant to ensure the ensembler and enricher config tables are up-to-date with the
+		// router version
+		if routerVersion.Enricher != nil {
+			err = tx.Save(routerVersion.Enricher).Error
+			if err != nil {
+				return nil, err
+			}
 		}
-		err = tx.Save(routerVersion.Ensembler).Error
-		if err != nil {
-			return nil, err
+		if routerVersion.Ensembler != nil {
+			err = tx.Save(routerVersion.Ensembler).Error
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/sdk/e2e/01_create_router_test.py
+++ b/sdk/e2e/01_create_router_test.py
@@ -65,10 +65,10 @@ def test_create_router():
     enricher = Enricher(
         image=os.getenv("TEST_ECHO_IMAGE"),
         resource_request=ResourceRequest(
-            min_replica=1, max_replica=1, cpu_request="100m", memory_request="1Gi"
+            min_replica=1, max_replica=1, cpu_request="250m", memory_request="256Mi"
         ),
-        endpoint="anything",
-        timeout="2s",
+        endpoint="enrich",
+        timeout="3s",
         port=80,
         env=[EnvVar(name="TEST_ENV", value="enricher")],
     )
@@ -77,9 +77,9 @@ def test_create_router():
     ensembler = DockerRouterEnsemblerConfig(
         image=os.getenv("TEST_ECHO_IMAGE"),
         resource_request=ResourceRequest(
-            min_replica=2, max_replica=2, cpu_request="100m", memory_request="256Mi"
+            min_replica=1, max_replica=1, cpu_request="250m", memory_request="256Mi"
         ),
-        endpoint="anything",
+        endpoint="ensemble",
         timeout="3s",
         port=80,
         env=[EnvVar(name="TEST_ENV", value="ensembler")],

--- a/sdk/e2e/06_deploy_valid_config_test.py
+++ b/sdk/e2e/06_deploy_valid_config_test.py
@@ -18,6 +18,14 @@ def test_deploy_router_valid_config():
     assert response["router_id"] == 1
     assert response["version"] == 1
 
+    # check that the status of the router is pending
+    try:
+        router.wait_for_status(RouterStatus.PENDING)
+    except TimeoutError:
+        raise Exception(
+            f"Turing API is taking too long for router {router.id} to start getting deployed."
+        )
+
     # wait for the router to get deployed
     try:
         router.wait_for_status(RouterStatus.DEPLOYED)


### PR DESCRIPTION
## Context
After the Gorm library has been updated to v2 in #261, there is a bug discovered in how we're using the Gorm methods to save router versions to the DB whereby nested fields (such as the ensembler configs) do not get updated in their respective tables. This has caused deployed pyfunc ensemblers to not have their corresponding docker configs updated in the `ensembler_configs` table. Since these are left as `NULL`, what then happens downstream is that the cluster controller fails to build KnativeService objects that correspond to the deployed ensembler instances, causing it to be unable to deploy ensemblers that have been deployed (either as part of a router update operation or an undeployment operation).

~~This PR introduces a config to the Gorm DB layer which adds a new field `FullSaveAssociations: true` to the existing Gorm DB configs, which would ensure that all tables get updated whenever Gorm is used to update a router version (or any other object for that matter of fact). See https://github.com/go-gorm/gorm/issues/6162 for more details.~~

This PR introduces additional steps to update the ensembler and enricher configs of a router version (these are stored in their respective tables) and were previously not getting updated whenever a router version is updated:
```go
err = tx.Save(routerVersion).Error
if err != nil {
	return nil, err
}

if routerVersion.Enricher != nil {
	err = tx.Save(routerVersion.Enricher).Error
	if err != nil {
		return nil, err
	}
}
if routerVersion.Ensembler != nil {
	err = tx.Save(routerVersion.Ensembler).Error
	if err != nil {
		return nil, err
	}
}
```

## Totally Unrelated Changes - Unused Arguments Clean Up
The linter's raising a lot of warnings about unused arguments so I've decided to remove them completely wherever possible, which is the case for the methods like `NewRouterEndpoint`, `NewEnricherService` and `NewEnsemblerService` since the existing implementations of the the `clusterSvcBuilder` don't even use them. And since these methods are concrete implementations of the interface `ClusterServiceBuilder`'s methods, I've also removed the arguments from them too, which then requires some minor refactoring of the methods of `mockClusterServiceBuilder` (which also implements the interface) and the tests where it is used.

Most notably, I've removed all instances of the following:
```go
			Labels: map[string]string{
				"env": envType,
			},
``` 
that's specified in the expected and mocked responses (in `api/turing/service/router_deployment_service_test.go`) since in no way is the actual implementation of the `clusterSvcBuilder` ever using the `envType` argument to set labels in the `KnativeService` struct returned. It's weird to continue mocking responses that set those labels and then configure the expected responses to include those labels.

In all other cases (the majority of them), I've simply renamed the remaining unused arguments to `_` so those should be pretty easy to look through.