### PR TITLE
Add topology spread constraints to deployments

### DIFF
--- a/api/turing/cluster/knative_service.go
+++ b/api/turing/cluster/knative_service.go
@@ -45,6 +45,9 @@ type KnativeService struct {
 	// and a % value (of the requested value) for cpu / memory based autoscaling.
 	AutoscalingTarget string `json:"autoscalingTarget"`
 
+	// TopologySpreadConstraints contains a list of topology spread constraint to be applied on the pods of this service
+	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints"`
+
 	// Resource properties
 	QueueProxyResourcePercentage    int     `json:"queueProxyResourcePercentage"`
 	UserContainerLimitRequestFactor float64 `json:"userContainerLimitRequestFactor"`
@@ -157,6 +160,10 @@ func (cfg *KnativeService) buildSvcSpec(
 		initContainers = cfg.buildInitContainer(cfg.InitContainers)
 	}
 
+	// Add Knative app name label to the match expressions of each topology spread constraint to spread out all
+	// the pods across the specified topologyKey
+	topologySpreadConstraints := cfg.appendPodSpreadingLabelSelectorsToTopologySpreadConstraints(revisionName)
+
 	return &knservingv1.ServiceSpec{
 		ConfigurationSpec: knservingv1.ConfigurationSpec{
 			Template: knservingv1.RevisionTemplateSpec{
@@ -167,9 +174,10 @@ func (cfg *KnativeService) buildSvcSpec(
 				},
 				Spec: knservingv1.RevisionSpec{
 					PodSpec: corev1.PodSpec{
-						Containers:     []corev1.Container{container},
-						Volumes:        cfg.Volumes,
-						InitContainers: initContainers,
+						Containers:                []corev1.Container{container},
+						Volumes:                   cfg.Volumes,
+						InitContainers:            initContainers,
+						TopologySpreadConstraints: topologySpreadConstraints,
 					},
 					TimeoutSeconds: &timeout,
 				},
@@ -192,4 +200,36 @@ func (cfg *KnativeService) getAutoscalingTarget() (string, error) {
 	}
 	// For all other metrics, we can use the supplied value as is.
 	return cfg.AutoscalingTarget, nil
+}
+
+// appendPodSpreadingLabelSelectorsToTopologySpreadConstraints adds the given revisionName as a label to the
+// match expressions of each topology spread constraint to spread out all the pods across the specified topologyKey
+func (cfg *KnativeService) appendPodSpreadingLabelSelectorsToTopologySpreadConstraints(
+	revisionName string,
+) []corev1.TopologySpreadConstraint {
+	podSpreadingLabelSelectorRequirement := metav1.LabelSelectorRequirement{
+		Key:      "app",
+		Operator: metav1.LabelSelectorOpIn,
+		Values:   []string{revisionName},
+	}
+
+	for i := range cfg.TopologySpreadConstraints {
+		if cfg.TopologySpreadConstraints[i].LabelSelector == nil {
+			cfg.TopologySpreadConstraints[i].LabelSelector = &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					podSpreadingLabelSelectorRequirement,
+				},
+			}
+		} else {
+			if cfg.TopologySpreadConstraints[i].LabelSelector.MatchExpressions == nil {
+				cfg.TopologySpreadConstraints[i].LabelSelector.MatchExpressions = make([]metav1.LabelSelectorRequirement, 0)
+			}
+			cfg.TopologySpreadConstraints[i].LabelSelector.MatchExpressions = append(
+				cfg.TopologySpreadConstraints[i].LabelSelector.MatchExpressions,
+				podSpreadingLabelSelectorRequirement,
+			)
+		}
+	}
+
+	return cfg.TopologySpreadConstraints
 }

--- a/api/turing/cluster/knative_service.go
+++ b/api/turing/cluster/knative_service.go
@@ -203,33 +203,21 @@ func (cfg *KnativeService) getAutoscalingTarget() (string, error) {
 }
 
 // appendPodSpreadingLabelSelectorsToTopologySpreadConstraints adds the given revisionName as a label to the
-// match expressions of each topology spread constraint to spread out all the pods across the specified topologyKey
+// match labels of each topology spread constraint to spread out all the pods across the specified topologyKey
 func (cfg *KnativeService) appendPodSpreadingLabelSelectorsToTopologySpreadConstraints(
 	revisionName string,
 ) []corev1.TopologySpreadConstraint {
-	podSpreadingLabelSelectorRequirement := metav1.LabelSelectorRequirement{
-		Key:      "app",
-		Operator: metav1.LabelSelectorOpIn,
-		Values:   []string{revisionName},
-	}
-
 	for i := range cfg.TopologySpreadConstraints {
 		if cfg.TopologySpreadConstraints[i].LabelSelector == nil {
 			cfg.TopologySpreadConstraints[i].LabelSelector = &metav1.LabelSelector{
-				MatchExpressions: []metav1.LabelSelectorRequirement{
-					podSpreadingLabelSelectorRequirement,
-				},
+				MatchLabels: map[string]string{"app": revisionName},
 			}
 		} else {
-			if cfg.TopologySpreadConstraints[i].LabelSelector.MatchExpressions == nil {
-				cfg.TopologySpreadConstraints[i].LabelSelector.MatchExpressions = make([]metav1.LabelSelectorRequirement, 0)
+			if cfg.TopologySpreadConstraints[i].LabelSelector.MatchLabels == nil {
+				cfg.TopologySpreadConstraints[i].LabelSelector.MatchLabels = make(map[string]string)
 			}
-			cfg.TopologySpreadConstraints[i].LabelSelector.MatchExpressions = append(
-				cfg.TopologySpreadConstraints[i].LabelSelector.MatchExpressions,
-				podSpreadingLabelSelectorRequirement,
-			)
+			cfg.TopologySpreadConstraints[i].LabelSelector.MatchLabels["app"] = revisionName
 		}
 	}
-
 	return cfg.TopologySpreadConstraints
 }

--- a/api/turing/cluster/knative_service_test.go
+++ b/api/turing/cluster/knative_service_test.go
@@ -354,8 +354,12 @@ func TestBuildKnativeServiceConfig(t *testing.T) {
 						TopologyKey:       "kubernetes.io/hostname",
 						WhenUnsatisfiable: corev1.DoNotSchedule,
 						LabelSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								"app-label": "spread",
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "app-expression",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"1"},
+								},
 							},
 						},
 					},
@@ -434,12 +438,8 @@ func TestBuildKnativeServiceConfig(t *testing.T) {
 											TopologyKey:       "kubernetes.io/hostname",
 											WhenUnsatisfiable: corev1.ScheduleAnyway,
 											LabelSelector: &metav1.LabelSelector{
-												MatchExpressions: []metav1.LabelSelectorRequirement{
-													{
-														Key:      "app",
-														Operator: metav1.LabelSelectorOpIn,
-														Values:   []string{"test-svc-0"},
-													},
+												MatchLabels: map[string]string{
+													"app": "test-svc-0",
 												},
 											},
 										},
@@ -449,13 +449,13 @@ func TestBuildKnativeServiceConfig(t *testing.T) {
 											WhenUnsatisfiable: corev1.DoNotSchedule,
 											LabelSelector: &metav1.LabelSelector{
 												MatchLabels: map[string]string{
-													"app-label": "spread",
+													"app": "test-svc-0",
 												},
 												MatchExpressions: []metav1.LabelSelectorRequirement{
 													{
-														Key:      "app",
+														Key:      "app-expression",
 														Operator: metav1.LabelSelectorOpIn,
-														Values:   []string{"test-svc-0"},
+														Values:   []string{"1"},
 													},
 												},
 											},
@@ -467,17 +467,13 @@ func TestBuildKnativeServiceConfig(t *testing.T) {
 											LabelSelector: &metav1.LabelSelector{
 												MatchLabels: map[string]string{
 													"app-label": "spread",
+													"app":       "test-svc-0",
 												},
 												MatchExpressions: []metav1.LabelSelectorRequirement{
 													{
 														Key:      "app-expression",
 														Operator: metav1.LabelSelectorOpIn,
 														Values:   []string{"1"},
-													},
-													{
-														Key:      "app",
-														Operator: metav1.LabelSelectorOpIn,
-														Values:   []string{"test-svc-0"},
 													},
 												},
 											},

--- a/api/turing/cluster/knative_service_test.go
+++ b/api/turing/cluster/knative_service_test.go
@@ -335,6 +335,164 @@ func TestBuildKnativeServiceConfig(t *testing.T) {
 				},
 			},
 		},
+		"topology spread constraints": {
+			serviceCfg: KnativeService{
+				BaseService:       baseSvc,
+				ContainerPort:     8080,
+				MinReplicas:       1,
+				MaxReplicas:       2,
+				AutoscalingMetric: "concurrency",
+				AutoscalingTarget: "1",
+				TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+					{
+						MaxSkew:           1,
+						TopologyKey:       "kubernetes.io/hostname",
+						WhenUnsatisfiable: corev1.ScheduleAnyway,
+					},
+					{
+						MaxSkew:           2,
+						TopologyKey:       "kubernetes.io/hostname",
+						WhenUnsatisfiable: corev1.DoNotSchedule,
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"app-label": "spread",
+							},
+						},
+					},
+					{
+						MaxSkew:           3,
+						TopologyKey:       "kubernetes.io/hostname",
+						WhenUnsatisfiable: corev1.DoNotSchedule,
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"app-label": "spread",
+							},
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "app-expression",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"1"},
+								},
+							},
+						},
+					},
+				},
+				IsClusterLocal:                  true,
+				QueueProxyResourcePercentage:    30,
+				UserContainerLimitRequestFactor: 1.5,
+				Protocol:                        routerConfig.UPI,
+			},
+			expectedSpec: knservingv1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-svc",
+					Namespace: "test-namespace",
+					Labels: map[string]string{
+						"labelKey":                          "labelVal",
+						"networking.knative.dev/visibility": "cluster-local",
+					},
+				},
+				Spec: knservingv1.ServiceSpec{
+					ConfigurationSpec: knservingv1.ConfigurationSpec{
+						Template: knservingv1.RevisionTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test-svc-0",
+								Labels: map[string]string{
+									"labelKey": "labelVal",
+								},
+								Annotations: map[string]string{
+									"autoscaling.knative.dev/minScale":                     "1",
+									"autoscaling.knative.dev/maxScale":                     "2",
+									"autoscaling.knative.dev/metric":                       "concurrency",
+									"autoscaling.knative.dev/target":                       "1",
+									"autoscaling.knative.dev/class":                        "kpa.autoscaling.knative.dev",
+									"queue.sidecar.serving.knative.dev/resourcePercentage": "30",
+								},
+							},
+							Spec: knservingv1.RevisionSpec{
+								PodSpec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{
+											Name:  podSpec.Containers[0].Name,
+											Image: podSpec.Containers[0].Image,
+											Ports: []corev1.ContainerPort{
+												{
+													Name:          "h2c",
+													ContainerPort: 8080,
+												},
+											},
+											Resources:      resources,
+											ReadinessProbe: podSpec.Containers[0].ReadinessProbe,
+											LivenessProbe:  podSpec.Containers[0].LivenessProbe,
+											VolumeMounts:   baseSvc.VolumeMounts,
+											Env:            envs,
+										},
+									},
+									Volumes: baseSvc.Volumes,
+									TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+										{
+											MaxSkew:           1,
+											TopologyKey:       "kubernetes.io/hostname",
+											WhenUnsatisfiable: corev1.ScheduleAnyway,
+											LabelSelector: &metav1.LabelSelector{
+												MatchExpressions: []metav1.LabelSelectorRequirement{
+													{
+														Key:      "app",
+														Operator: metav1.LabelSelectorOpIn,
+														Values:   []string{"test-svc-0"},
+													},
+												},
+											},
+										},
+										{
+											MaxSkew:           2,
+											TopologyKey:       "kubernetes.io/hostname",
+											WhenUnsatisfiable: corev1.DoNotSchedule,
+											LabelSelector: &metav1.LabelSelector{
+												MatchLabels: map[string]string{
+													"app-label": "spread",
+												},
+												MatchExpressions: []metav1.LabelSelectorRequirement{
+													{
+														Key:      "app",
+														Operator: metav1.LabelSelectorOpIn,
+														Values:   []string{"test-svc-0"},
+													},
+												},
+											},
+										},
+										{
+											MaxSkew:           3,
+											TopologyKey:       "kubernetes.io/hostname",
+											WhenUnsatisfiable: corev1.DoNotSchedule,
+											LabelSelector: &metav1.LabelSelector{
+												MatchLabels: map[string]string{
+													"app-label": "spread",
+												},
+												MatchExpressions: []metav1.LabelSelectorRequirement{
+													{
+														Key:      "app-expression",
+														Operator: metav1.LabelSelectorOpIn,
+														Values:   []string{"1"},
+													},
+													{
+														Key:      "app",
+														Operator: metav1.LabelSelectorOpIn,
+														Values:   []string{"test-svc-0"},
+													},
+												},
+											},
+										},
+									},
+								},
+								TimeoutSeconds:       &timeout,
+								ContainerConcurrency: &defaultConcurrency,
+							},
+						},
+					},
+					RouteSpec: defaultRouteSpec,
+				},
+			},
+		},
 	}
 
 	for name, data := range tests {

--- a/api/turing/cluster/servicebuilder/router.go
+++ b/api/turing/cluster/servicebuilder/router.go
@@ -127,6 +127,12 @@ func (sb *clusterSvcBuilder) NewRouterService(
 	if err != nil {
 		return nil, err
 	}
+
+	topologySpreadConstraints, err := sb.getTopologySpreadConstraints()
+	if err != nil {
+		return nil, err
+	}
+
 	svc := &cluster.KnativeService{
 		BaseService: &cluster.BaseService{
 			Name:                 name,
@@ -150,6 +156,7 @@ func (sb *clusterSvcBuilder) NewRouterService(
 		MaxReplicas:                     routerVersion.ResourceRequest.MaxReplica,
 		AutoscalingMetric:               string(routerVersion.AutoscalingPolicy.Metric),
 		AutoscalingTarget:               routerVersion.AutoscalingPolicy.Target,
+		TopologySpreadConstraints:       topologySpreadConstraints,
 		QueueProxyResourcePercentage:    knativeQueueProxyResourcePercentage,
 		UserContainerLimitRequestFactor: userContainerLimitRequestFactor,
 	}

--- a/api/turing/cluster/servicebuilder/router_test.go
+++ b/api/turing/cluster/servicebuilder/router_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestNewRouterService(t *testing.T) {
-	sb := NewClusterServiceBuilder(resource.MustParse("2"), resource.MustParse("2Gi"), 30)
+	sb := NewClusterServiceBuilder(resource.MustParse("2"), resource.MustParse("2Gi"), 30, testTopologySpreadConstraints)
 	testDataBasePath := filepath.Join("..", "..", "testdata", "cluster", "servicebuilder")
 	enrEndpoint := "http://test-svc-turing-enricher-1.test-project.svc.cluster.local/echo?delay=10ms"
 	ensEndpoint := "http://test-svc-turing-ensembler-1.test-project.svc.cluster.local/echo?delay=20ms"
@@ -165,6 +165,7 @@ func TestNewRouterService(t *testing.T) {
 				MaxReplicas:                     4,
 				AutoscalingMetric:               "concurrency",
 				AutoscalingTarget:               "1",
+				TopologySpreadConstraints:       testTopologySpreadConstraints,
 				QueueProxyResourcePercentage:    20,
 				UserContainerLimitRequestFactor: 1.5,
 			},
@@ -263,6 +264,7 @@ func TestNewRouterService(t *testing.T) {
 				MaxReplicas:                     4,
 				AutoscalingMetric:               "concurrency",
 				AutoscalingTarget:               "1",
+				TopologySpreadConstraints:       testTopologySpreadConstraints,
 				QueueProxyResourcePercentage:    20,
 				UserContainerLimitRequestFactor: 1.5,
 			},
@@ -369,6 +371,7 @@ func TestNewRouterService(t *testing.T) {
 				MaxReplicas:                     4,
 				AutoscalingMetric:               "concurrency",
 				AutoscalingTarget:               "1",
+				TopologySpreadConstraints:       testTopologySpreadConstraints,
 				QueueProxyResourcePercentage:    20,
 				UserContainerLimitRequestFactor: 1.5,
 			},
@@ -467,6 +470,7 @@ func TestNewRouterService(t *testing.T) {
 				MaxReplicas:                     4,
 				AutoscalingMetric:               "rps",
 				AutoscalingTarget:               "100",
+				TopologySpreadConstraints:       testTopologySpreadConstraints,
 				QueueProxyResourcePercentage:    20,
 				UserContainerLimitRequestFactor: 1.5,
 			},
@@ -565,6 +569,7 @@ func TestNewRouterService(t *testing.T) {
 				MaxReplicas:                     4,
 				AutoscalingMetric:               "rps",
 				AutoscalingTarget:               "100",
+				TopologySpreadConstraints:       testTopologySpreadConstraints,
 				QueueProxyResourcePercentage:    20,
 				UserContainerLimitRequestFactor: 1.5,
 			},
@@ -663,6 +668,7 @@ func TestNewRouterService(t *testing.T) {
 				MaxReplicas:                     4,
 				AutoscalingMetric:               "rps",
 				AutoscalingTarget:               "100",
+				TopologySpreadConstraints:       testTopologySpreadConstraints,
 				QueueProxyResourcePercentage:    20,
 				UserContainerLimitRequestFactor: 1.5,
 			},
@@ -761,6 +767,7 @@ func TestNewRouterService(t *testing.T) {
 				MaxReplicas:                     4,
 				AutoscalingMetric:               "concurrency",
 				AutoscalingTarget:               "1",
+				TopologySpreadConstraints:       testTopologySpreadConstraints,
 				QueueProxyResourcePercentage:    20,
 				UserContainerLimitRequestFactor: 1.5,
 			},
@@ -888,6 +895,7 @@ func TestNewRouterService(t *testing.T) {
 				MaxReplicas:                     4,
 				AutoscalingMetric:               "rps",
 				AutoscalingTarget:               "100",
+				TopologySpreadConstraints:       testTopologySpreadConstraints,
 				QueueProxyResourcePercentage:    20,
 				UserContainerLimitRequestFactor: 1.5,
 			},
@@ -963,6 +971,7 @@ func TestNewRouterService(t *testing.T) {
 				MaxReplicas:                     4,
 				AutoscalingMetric:               "memory",
 				AutoscalingTarget:               "90",
+				TopologySpreadConstraints:       testTopologySpreadConstraints,
 				QueueProxyResourcePercentage:    20,
 				UserContainerLimitRequestFactor: 1.5,
 			},
@@ -1016,7 +1025,7 @@ func TestNewRouterService(t *testing.T) {
 
 func TestNewRouterEndpoint(t *testing.T) {
 	// Get router version
-	sb := NewClusterServiceBuilder(resource.MustParse("2"), resource.MustParse("2Gi"), 30)
+	sb := NewClusterServiceBuilder(resource.MustParse("2"), resource.MustParse("2Gi"), 30, testTopologySpreadConstraints)
 	testDataBasePath := filepath.Join("..", "..", "testdata", "cluster", "servicebuilder")
 	fileBytes, err := tu.ReadFile(filepath.Join(testDataBasePath, "router_version_success.json"))
 	require.NoError(t, err)

--- a/api/turing/cluster/servicebuilder/service_builder_test.go
+++ b/api/turing/cluster/servicebuilder/service_builder_test.go
@@ -18,28 +18,10 @@ import (
 
 var testTopologySpreadConstraints = []corev1.TopologySpreadConstraint{
 	{
-		MaxSkew:           1,
-		TopologyKey:       "kubernetes.io/hostname",
-		WhenUnsatisfiable: corev1.ScheduleAnyway,
-	},
-	{
 		MaxSkew:           2,
 		TopologyKey:       "kubernetes.io/hostname",
 		WhenUnsatisfiable: corev1.DoNotSchedule,
 		LabelSelector: &metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				"app-label": "spread",
-			},
-		},
-	},
-	{
-		MaxSkew:           3,
-		TopologyKey:       "kubernetes.io/hostname",
-		WhenUnsatisfiable: corev1.DoNotSchedule,
-		LabelSelector: &metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				"app-label": "spread",
-			},
 			MatchExpressions: []metav1.LabelSelectorRequirement{
 				{
 					Key:      "app-expression",

--- a/api/turing/config/config.go
+++ b/api/turing/config/config.go
@@ -10,12 +10,12 @@ import (
 	"time"
 
 	"github.com/go-playground/validator/v10"
+	mlpcluster "github.com/gojek/mlp/api/pkg/cluster"
 	"github.com/gojek/mlp/api/pkg/instrumentation/newrelic"
 	"github.com/gojek/mlp/api/pkg/instrumentation/sentry"
 	"github.com/mitchellh/mapstructure"
 	"gopkg.in/yaml.v2"
-
-	mlpcluster "github.com/gojek/mlp/api/pkg/cluster"
+	corev1 "k8s.io/api/core/v1"
 
 	openapi "github.com/caraml-dev/turing/api/turing/generated"
 	"github.com/caraml-dev/turing/api/turing/utils"
@@ -222,12 +222,13 @@ type SparkAppConfig struct {
 
 // DeploymentConfig captures the config related to the deployment of the turing routers
 type DeploymentConfig struct {
-	EnvironmentType   string        `validate:"required"`
-	Timeout           time.Duration `validate:"required"`
-	DeletionTimeout   time.Duration `validate:"required"`
-	MaxCPU            Quantity      `validate:"required"`
-	MaxMemory         Quantity      `validate:"required"`
-	MaxAllowedReplica int           `validate:"required"`
+	EnvironmentType           string        `validate:"required"`
+	Timeout                   time.Duration `validate:"required"`
+	DeletionTimeout           time.Duration `validate:"required"`
+	MaxCPU                    Quantity      `validate:"required"`
+	MaxMemory                 Quantity      `validate:"required"`
+	MaxAllowedReplica         int           `validate:"required"`
+	TopologySpreadConstraints []corev1.TopologySpreadConstraint
 }
 
 // KubernetesLabelConfigs are the configurations for labeling

--- a/api/turing/config/config_test.go
+++ b/api/turing/config/config_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	mlpcluster "github.com/gojek/mlp/api/pkg/cluster"
 	clientcmdapiv1 "k8s.io/client-go/tools/clientcmd/api/v1"
@@ -219,6 +221,40 @@ func TestLoad(t *testing.T) {
 					MaxCPU:            config.Quantity(resource.MustParse("500m")),
 					MaxMemory:         config.Quantity(resource.MustParse("4000Mi")),
 					MaxAllowedReplica: 20,
+					TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+						{
+							MaxSkew:           1,
+							TopologyKey:       "kubernetes.io/hostname",
+							WhenUnsatisfiable: corev1.ScheduleAnyway,
+						},
+						{
+							MaxSkew:           2,
+							TopologyKey:       "kubernetes.io/hostname",
+							WhenUnsatisfiable: corev1.DoNotSchedule,
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"app-label": "spread",
+								},
+							},
+						},
+						{
+							MaxSkew:           3,
+							TopologyKey:       "kubernetes.io/hostname",
+							WhenUnsatisfiable: corev1.DoNotSchedule,
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"app-label": "spread",
+								},
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      "app-expression",
+										Operator: metav1.LabelSelectorOpIn,
+										Values:   []string{"1"},
+									},
+								},
+							},
+						},
+					},
 				},
 				KnativeServiceDefaults: &config.KnativeServiceDefaults{
 					QueueProxyResourcePercentage:    20,
@@ -322,6 +358,40 @@ func TestLoad(t *testing.T) {
 					MaxCPU:            config.Quantity(resource.MustParse("500m")),
 					MaxMemory:         config.Quantity(resource.MustParse("12Gi")),
 					MaxAllowedReplica: 30,
+					TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+						{
+							MaxSkew:           1,
+							TopologyKey:       "kubernetes.io/hostname",
+							WhenUnsatisfiable: corev1.ScheduleAnyway,
+						},
+						{
+							MaxSkew:           2,
+							TopologyKey:       "kubernetes.io/hostname",
+							WhenUnsatisfiable: corev1.DoNotSchedule,
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"app-label": "spread",
+								},
+							},
+						},
+						{
+							MaxSkew:           3,
+							TopologyKey:       "kubernetes.io/hostname",
+							WhenUnsatisfiable: corev1.DoNotSchedule,
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"app-label": "spread",
+								},
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      "app-expression",
+										Operator: metav1.LabelSelectorOpIn,
+										Values:   []string{"1"},
+									},
+								},
+							},
+						},
+					},
 				},
 				KnativeServiceDefaults: &config.KnativeServiceDefaults{
 					QueueProxyResourcePercentage:    20,
@@ -464,6 +534,40 @@ func TestLoad(t *testing.T) {
 					MaxCPU:            config.Quantity(resource.MustParse("500m")),
 					MaxMemory:         config.Quantity(resource.MustParse("4500Mi")),
 					MaxAllowedReplica: 30,
+					TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+						{
+							MaxSkew:           1,
+							TopologyKey:       "kubernetes.io/hostname",
+							WhenUnsatisfiable: corev1.ScheduleAnyway,
+						},
+						{
+							MaxSkew:           2,
+							TopologyKey:       "kubernetes.io/hostname",
+							WhenUnsatisfiable: corev1.DoNotSchedule,
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"app-label": "spread",
+								},
+							},
+						},
+						{
+							MaxSkew:           3,
+							TopologyKey:       "kubernetes.io/hostname",
+							WhenUnsatisfiable: corev1.DoNotSchedule,
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"app-label": "spread",
+								},
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      "app-expression",
+										Operator: metav1.LabelSelectorOpIn,
+										Values:   []string{"1"},
+									},
+								},
+							},
+						},
+					},
 				},
 				RouterDefaults: &config.RouterDefaults{
 					LogLevel: "INFO",

--- a/api/turing/config/testdata/config-1.yaml
+++ b/api/turing/config/testdata/config-1.yaml
@@ -18,6 +18,27 @@ DeployConfig:
   Timeout: 5m
   MaxCPU: 500m
   MaxMemory: 4000Mi
+  TopologySpreadConstraints:
+    - MaxSkew: 1
+      TopologyKey: kubernetes.io/hostname
+      WhenUnsatisfiable: ScheduleAnyway
+    - MaxSkew: 2
+      TopologyKey: kubernetes.io/hostname
+      WhenUnsatisfiable: DoNotSchedule
+      LabelSelector:
+        MatchLabels:
+          app-label: spread
+    - MaxSkew: 3
+      TopologyKey: kubernetes.io/hostname
+      WhenUnsatisfiable: DoNotSchedule
+      LabelSelector:
+        MatchLabels:
+          app-label: spread
+        MatchExpressions:
+          - Key: app-expression
+            Operator: In
+            Values:
+              - 1
 KnativeServiceDefaults:
   QueueProxyResourcePercentage: 20
   UserContainerLimitRequestFactor: 1.25

--- a/api/turing/service/router_deployment_service.go
+++ b/api/turing/service/router_deployment_service.go
@@ -87,6 +87,7 @@ func NewDeploymentService(
 		resource.Quantity(cfg.DeployConfig.MaxCPU),
 		resource.Quantity(cfg.DeployConfig.MaxMemory),
 		cfg.DeployConfig.MaxAllowedReplica,
+		cfg.DeployConfig.TopologySpreadConstraints,
 	)
 
 	return &deploymentService{

--- a/infra/cluster-init/knative-configmaps/config-features.yaml
+++ b/infra/cluster-init/knative-configmaps/config-features.yaml
@@ -12,3 +12,4 @@ metadata:
 data:
   kubernetes.podspec-volumes-emptydir: "enabled"
   kubernetes.podspec-init-containers: "enabled"
+  kubernetes.podspec-topologyspreadconstraints: "enabled"


### PR DESCRIPTION
## Context
[Topology spread constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) allow the distribution of pods across various topology domains to be controlled at a finer level than with pod affinities/anti-affinities. As the current implementation of the Turing API server does not allow Knative services (Turing Routers, enrichers, pyfunc/docker ensemblers) to be deployed with topology spread constraints, this PR introduces changes to allow the Turing API server operator to specify topology spread constraints in the Turing API configuration which will get propagated to all Knative services deployed. 

In addition, in order to encourage pods of the same Knative service deployed by the Turing API server to be scheduled on a largest variety of nodes wherever possible to encourage high availability, an additional match label is added by default to all constraints specified in the Turing API configuration:
```yaml
matchLabels:
    app: [knative-service-name]
```
The above behaviour occurs for all constraints, even those without any other match labels or label selectors specified.

## Modifications
- `api/turing/cluster/knative_service.go` - Addition of steps to inject the aforementioned additional match label to all constraints of the Knative service to be deployed
- `api/turing/cluster/servicebuilder/service_builder.go` - Addition of methods to store the constraints specified in the Turing API configuration and copy them onto any Knative service to be deployed
- `api/turing/config/config.go` - Addition of an additional `TopologySpreadConstraints` field to read the constraints stored in the Turing API configuration