### PR TITLE
Bugfix: Update navbar project URL

### DIFF
--- a/ui/src/PrivateLayout.js
+++ b/ui/src/PrivateLayout.js
@@ -24,7 +24,7 @@ export const PrivateLayout = () => {
               {({ currentApp }) => (
                 <Header
                   onProjectSelect={pId =>
-                    navigate(urlJoin(currentApp?.href, "projects", pId, "routers"))
+                    navigate(urlJoin(currentApp?.homepage, "projects", pId, "routers"))
                   }
                   docLinks={appConfig.docsUrl}
                 />)}


### PR DESCRIPTION
With the Applications v2 API introduced in https://github.com/caraml-dev/mlp/pull/72, the homepage URL is supposed to be read from the `homepage` property of the current app stored in the applications context, as opposed to `.href`. The MLP PR was integrated to Turing through the UI library bump done in https://github.com/caraml-dev/turing/pull/333. This PR updates the nav URL accordingly.

<img width="747" alt="Screenshot 2023-04-20 at 11 40 19 AM" src="https://user-images.githubusercontent.com/23465343/233254140-703fa05c-ec5a-4281-a48b-1581ef83cac3.png">
