### PR TITLE
skip: Introduce semver to workflows

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,72 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: 'Breaking 🔨'
+    label: 'type: breaking'
+  - title: 'New 🚀'
+    label: 'type: feature'
+  - title: 'Bug Fixes 🐛'
+    label: 'type: bug'
+  - title: 'Maintenance ⚙️'
+    label: 'type: maintenance'
+  - title: 'Documentation 📄'
+    label: 'type: documentation'
+  - title: 'Other changes'
+  - title: 'Dependency Updates 💪'
+    label: 'type: dependencies'
+    collapse-after: 5
+
+version-resolver:
+  major:
+    labels:
+      - 'type: breaking'
+  minor:
+    labels:
+      - 'type: feature'
+  patch:
+    labels:
+      - 'type: bug'
+      - 'type: maintenance'
+      - 'type: documentation'
+      - 'type: dependencies'
+      - 'type: security'
+      - 'type: others'
+  default: patch
+
+exclude-labels:
+  - 'skip-changelog'
+
+autolabeler:
+  - label: 'type: breaking'
+    title:
+      - '/^(breaking)/i'
+  - label: 'type: feature'
+    title:
+      - '/^(feat)/i'
+  - label: 'type: documentation'
+    title:
+      - '/^(docs)/i'
+  - label: 'type: bug'
+    title:
+      - '/^(fix)/i'
+  - label: 'type: maintenance'
+    title:
+      - '/^(chore)/i'
+  - label: 'type: dependencies'
+    title:
+      - '/^(build)/i'
+  - label: 'type: security'
+    title:
+      - '/^(security)/i'
+  - label: 'type: others'
+    title:
+      - '/^(others)/i'
+  - label: 'skip-changelog'
+    title:
+      - '/^(skip)/i'
+template: |
+  ## Changes
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -1,0 +1,41 @@
+name: PR Lint
+
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+
+jobs:
+  pr-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            breaking
+            feat
+            docs
+            chore
+            security
+            others
+            skip
+  update-pr-labels:
+    needs: pr-title
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        # Only want to use auto-labeler
+        with:
+          config-name: release-drafter.yml
+          disable-autolabeler: false
+          disable-releaser: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true

--- a/.github/workflows/release-draft.yaml
+++ b/.github/workflows/release-draft.yaml
@@ -1,0 +1,25 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts the next Release notes as Pull Requests are merged into "main"
+      - uses: release-drafter/release-drafter@v5
+        # Specify config name to use, relative to .github/
+        with:
+          config-name: release-drafter.yml
+          disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR introduces `Semantic Versioning` when releasing `turing`.

Specifically, the following updates have been made to the workflow:
- All PRs require a prefix that would auto-label the PR
- Auto-labeling has been added, which caters to the following categories for `release-drafter`:

Version Bump Category | PR Title <> matching label
--- | ---
MAJOR | `breaking: ...` <> `breaking`
MINOR | `feat: ...` <> `feature`
PATCH | `fix: ...` <> bug<br/>`docs: ...` <> documentation<br/>`chore: ...` <> maintenance<br/>`build: ...` <> dependencies<br/>`security: ...` <> security<br/>`others: ...` <> others
NONE | `skip: ...` <> `skip-changelog`

Relevant Documentation:
- https://github.com/amannn/action-semantic-pull-request
- https://www.conventionalcommits.org/