### PR TITLE
Bugfix: remove validation for resultlogger of upi router in sdk

### DIFF
--- a/sdk/tests/router/config/router_config_test.py
+++ b/sdk/tests/router/config/router_config_test.py
@@ -198,41 +198,6 @@ def test_default_router_autoscaling_policy(request):
 
 
 @pytest.mark.parametrize(
-    "base_config, log_config, expected",
-    [
-        pytest.param(
-            "minimal_upi_router_config",
-            LogConfig(result_logger_type=ResultLoggerType.NOP),
-            None,
-        ),
-        pytest.param(
-            "minimal_upi_router_config",
-            LogConfig(result_logger_type=ResultLoggerType.UPI),
-            None,
-        ),
-        pytest.param(
-            "minimal_upi_router_config",
-            LogConfig(result_logger_type=ResultLoggerType.KAFKA),
-            InvalidResultLoggerTypeAndConfigCombination,
-        ),
-        pytest.param(
-            "minimal_upi_router_config",
-            LogConfig(result_logger_type=ResultLoggerType.BIGQUERY),
-            InvalidResultLoggerTypeAndConfigCombination,
-        ),
-    ],
-)
-def test_upi_router_log_config_constraint(base_config, log_config, expected, request):
-    router_config = request.getfixturevalue(base_config)
-    if expected:
-        with pytest.raises(expected):
-            router_config.log_config = log_config
-    else:
-        router_config.log_config = log_config
-        router_config.to_open_api()
-
-
-@pytest.mark.parametrize(
     "base_config, ensembler_config, expected_err",
     [
         pytest.param(

--- a/sdk/turing/router/config/router_config.py
+++ b/sdk/turing/router/config/router_config.py
@@ -277,9 +277,6 @@ class RouterConfig:
             self._log_config = LogConfig(**log_config)
         else:
             self._log_config = log_config
-        # Verify that only nop or UPI logger is configured for UPI router
-        if self._protocol == Protocol.UPI:
-            self._verify_upi_router_logger()
 
     @property
     def enricher(self) -> Enricher:
@@ -420,16 +417,6 @@ class RouterConfig:
         ):
             raise turing.router.config.router_ensembler_config.InvalidEnsemblerTypeException(
                 f"UPI router only supports no ensembler or standard ensembler."
-            )
-
-    def _verify_upi_router_logger(self):
-        # only nop or upi logger type is allowed
-        if not (
-            self.log_config.result_logger_type == ResultLoggerType.NOP
-            or self.log_config.result_logger_type == ResultLoggerType.UPI
-        ):
-            raise turing.router.config.log_config.InvalidResultLoggerTypeAndConfigCombination(
-                f"UPI router only supports no logging or UPI logger"
             )
 
     def to_dict(self):


### PR DESCRIPTION
# Description
Short: Remove validation in SDK for UPI Router that was missed earlier on.

When UPI Logger was [first introduced](https://github.com/caraml-dev/turing/pull/319/files#diff-49fa6d9d67eac9ae9ac62b762e4db2c2b72de2d407f4a5aa1930e94a0f187a97), it was never intended to work with BQ/Kafka ResultLogger. 

Subsequently, BQ/Kafka logger are enabled for UPI Router in this [PR](https://github.com/caraml-dev/turing/pull/323/files#diff-2bc7d30f97d4ecb41bd4e1ac0a1727086edf6557f30f409991db83e1d7278bcd) 
using `TuringResultLog` instead of `RouterLog` and the validation for these were removed for the API Server but not SDK.

This PR removes the SDK validations that should had been removing with the previous PR.