### PR TITLE
feat: Add authz caching config

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/GoogleCloudPlatform/spark-on-k8s-operator v0.0.0-20220214044918-55732a6a392c
 	github.com/antihax/optional v1.0.0
 	github.com/caraml-dev/merlin v0.0.0
-	github.com/caraml-dev/mlp v1.7.7-0.20230519042541-3415407aa27b
+	github.com/caraml-dev/mlp v1.8.1-0.20230613010931-dd63f4364a18
 	github.com/caraml-dev/turing/engines/experiment v0.0.0
 	github.com/caraml-dev/turing/engines/router v0.0.0
 	github.com/caraml-dev/universal-prediction-interface v0.3.4

--- a/api/go.sum
+++ b/api/go.sum
@@ -244,8 +244,8 @@ github.com/cactus/go-statsd-client/statsd v0.0.0-20200423205355-cb0885a1018c/go.
 github.com/caraml-dev/merlin/api v0.0.0-20230403075012-795947162429 h1:utxGPa/erqKIUhgBFMgnbORjKUIqVKLs7VXa0ZB0jNY=
 github.com/caraml-dev/merlin/api v0.0.0-20230403075012-795947162429/go.mod h1:BRGKVbv3zEu9rE6pE2RNlj/IZfqy/3HEqBQGLK5rHMc=
 github.com/caraml-dev/merlin/python/batch-predictor v0.0.0-20230403075012-795947162429/go.mod h1:jYSIcxx7FDccKSva3mo12YhQ0rYuP4MOEbgSveY82HE=
-github.com/caraml-dev/mlp v1.7.7-0.20230519042541-3415407aa27b h1:gnHGvCi48tbpWyvIIN9T51OjjBPN87CSjlNezq74H9s=
-github.com/caraml-dev/mlp v1.7.7-0.20230519042541-3415407aa27b/go.mod h1:KwanmpEzX11cIczhSs7e55M0EvgTuiZWC+uHQYppG5U=
+github.com/caraml-dev/mlp v1.8.1-0.20230613010931-dd63f4364a18 h1:/Rjw7+qVMo+rBaBqzJZrtQ1lKXb3KXeTXP1lJOTT7xI=
+github.com/caraml-dev/mlp v1.8.1-0.20230613010931-dd63f4364a18/go.mod h1:dNqC/QnXYpkxWDaV6XU8y1UJTjmKJC3Z6CpW1n9Hjd0=
 github.com/caraml-dev/universal-prediction-interface v0.3.4 h1:cPytzpjXE/8RhSw3iS0JFZzNdM3tJ/l8UcHTPrxQWEo=
 github.com/caraml-dev/universal-prediction-interface v0.3.4/go.mod h1:e0qmFOXQxx8HFg5ObYyQO3WVnrqsr5v5JApFmeF7eJo=
 github.com/casbin/casbin v1.7.0/go.mod h1:c67qKN6Oum3UF5Q1+BByfFxkwKvhwW57ITjqwtzR1KE=

--- a/api/turing/config/config.go
+++ b/api/turing/config/config.go
@@ -353,6 +353,13 @@ type UPIConfig struct {
 type AuthorizationConfig struct {
 	Enabled bool
 	URL     string
+	Caching *InMemoryCacheConfig `validate:"required_if=Enabled True"`
+}
+
+type InMemoryCacheConfig struct {
+	Enabled                     bool
+	KeyExpirySeconds            int `validate:"required_if=Enabled True"`
+	CacheCleanUpIntervalSeconds int `validate:"required_if=Enabled True"`
 }
 
 // ClusterConfig contains the cluster controller information.
@@ -556,6 +563,8 @@ func setDefaultValues(v *viper.Viper) {
 
 	v.SetDefault("AuthConfig::Enabled", "false")
 	v.SetDefault("AuthConfig::URL", "")
+	v.SetDefault("AuthConfig::Caching::KeyExpirySeconds", "600")
+	v.SetDefault("AuthConfig::Caching::CacheCleanUpIntervalSeconds", "900")
 
 	v.SetDefault("DbConfig::Host", "localhost")
 	v.SetDefault("DbConfig::Port", "5432")

--- a/api/turing/config/config_test.go
+++ b/api/turing/config/config_test.go
@@ -3,6 +3,7 @@ package config_test
 import (
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -68,8 +69,9 @@ func TestGetters(t *testing.T) {
 
 func TestAuthConfigValidation(t *testing.T) {
 	tests := map[string]struct {
-		cfg     config.AuthorizationConfig
-		success bool
+		cfg         config.AuthorizationConfig
+		success     bool
+		expectedErr string
 	}{
 		"success auth disabled": {
 			cfg: config.AuthorizationConfig{
@@ -81,6 +83,21 @@ func TestAuthConfigValidation(t *testing.T) {
 			cfg: config.AuthorizationConfig{
 				Enabled: true,
 				URL:     "url",
+				Caching: &config.InMemoryCacheConfig{
+					Enabled: false,
+				},
+			},
+			success: true,
+		},
+		"success caching enabled": {
+			cfg: config.AuthorizationConfig{
+				Enabled: true,
+				URL:     "url",
+				Caching: &config.InMemoryCacheConfig{
+					Enabled:                     true,
+					KeyExpirySeconds:            100,
+					CacheCleanUpIntervalSeconds: 200,
+				},
 			},
 			success: true,
 		},
@@ -88,7 +105,22 @@ func TestAuthConfigValidation(t *testing.T) {
 			cfg: config.AuthorizationConfig{
 				Enabled: true,
 			},
+			success:     false,
+			expectedErr: "Key: 'AuthorizationConfig.Caching' Error:Field validation for 'Caching' failed on the 'required_if' tag",
+		},
+		"failure caching enabled no duration config": {
+			cfg: config.AuthorizationConfig{
+				Enabled: true,
+				URL:     "url",
+				Caching: &config.InMemoryCacheConfig{
+					Enabled: true,
+				},
+			},
 			success: false,
+			expectedErr: strings.Join([]string{
+				"Key: 'AuthorizationConfig.Caching.KeyExpirySeconds' Error:Field validation for 'KeyExpirySeconds' failed on the 'required_if' tag\n",
+				"Key: 'AuthorizationConfig.Caching.CacheCleanUpIntervalSeconds' Error:Field validation for 'CacheCleanUpIntervalSeconds' failed on the 'required_if' tag",
+			}, ""),
 		},
 	}
 
@@ -133,7 +165,12 @@ func TestLoad(t *testing.T) {
 			want: &config.Config{
 				Port:           8080,
 				AllowedOrigins: []string{"*"},
-				AuthConfig:     &config.AuthorizationConfig{},
+				AuthConfig: &config.AuthorizationConfig{
+					Caching: &config.InMemoryCacheConfig{
+						KeyExpirySeconds:            600,
+						CacheCleanUpIntervalSeconds: 900,
+					},
+				},
 				DbConfig: &config.DatabaseConfig{
 					Host:             "localhost",
 					Port:             5432,
@@ -201,6 +238,10 @@ func TestLoad(t *testing.T) {
 				AuthConfig: &config.AuthorizationConfig{
 					Enabled: true,
 					URL:     "http://example.com",
+					Caching: &config.InMemoryCacheConfig{
+						KeyExpirySeconds:            600,
+						CacheCleanUpIntervalSeconds: 900,
+					},
 				},
 				DbConfig: &config.DatabaseConfig{
 					Host:             "127.0.0.1",
@@ -338,6 +379,10 @@ func TestLoad(t *testing.T) {
 				AuthConfig: &config.AuthorizationConfig{
 					Enabled: false,
 					URL:     "http://example.com",
+					Caching: &config.InMemoryCacheConfig{
+						KeyExpirySeconds:            600,
+						CacheCleanUpIntervalSeconds: 900,
+					},
 				},
 				DbConfig: &config.DatabaseConfig{
 					Host:             "127.0.0.1",
@@ -489,6 +534,7 @@ func TestLoad(t *testing.T) {
 				"ALLOWEDORIGINS":                                 "http://baz.com,http://qux.com",
 				"AUTHCONFIG_ENABLED":                             "true",
 				"AUTHCONFIG_URL":                                 "http://env.example.com",
+				"AUTHCONFIG_CACHING_ENABLED":                     "true",
 				"DBCONFIG_USER":                                  "dbuser-env",
 				"DBCONFIG_PASSWORD":                              "dbpassword-env",
 				"DEPLOYCONFIG_TIMEOUT":                           "10m",
@@ -510,6 +556,11 @@ func TestLoad(t *testing.T) {
 				AuthConfig: &config.AuthorizationConfig{
 					Enabled: true,
 					URL:     "http://env.example.com",
+					Caching: &config.InMemoryCacheConfig{
+						Enabled:                     true,
+						KeyExpirySeconds:            600,
+						CacheCleanUpIntervalSeconds: 900,
+					},
 				},
 				DbConfig: &config.DatabaseConfig{
 					Host:             "127.0.0.1",

--- a/api/turing/config/config_test.go
+++ b/api/turing/config/config_test.go
@@ -105,8 +105,11 @@ func TestAuthConfigValidation(t *testing.T) {
 			cfg: config.AuthorizationConfig{
 				Enabled: true,
 			},
-			success:     false,
-			expectedErr: "Key: 'AuthorizationConfig.Caching' Error:Field validation for 'Caching' failed on the 'required_if' tag",
+			success: false,
+			expectedErr: strings.Join([]string{
+				"Key: 'AuthorizationConfig.Caching' ",
+				"Error:Field validation for 'Caching' failed on the 'required_if' tag",
+			}, ""),
 		},
 		"failure caching enabled no duration config": {
 			cfg: config.AuthorizationConfig{
@@ -118,8 +121,10 @@ func TestAuthConfigValidation(t *testing.T) {
 			},
 			success: false,
 			expectedErr: strings.Join([]string{
-				"Key: 'AuthorizationConfig.Caching.KeyExpirySeconds' Error:Field validation for 'KeyExpirySeconds' failed on the 'required_if' tag\n",
-				"Key: 'AuthorizationConfig.Caching.CacheCleanUpIntervalSeconds' Error:Field validation for 'CacheCleanUpIntervalSeconds' failed on the 'required_if' tag",
+				"Key: 'AuthorizationConfig.Caching.KeyExpirySeconds' ",
+				"Error:Field validation for 'KeyExpirySeconds' failed on the 'required_if' tag\n",
+				"Key: 'AuthorizationConfig.Caching.CacheCleanUpIntervalSeconds' ",
+				"Error:Field validation for 'CacheCleanUpIntervalSeconds' failed on the 'required_if' tag",
 			}, ""),
 		},
 	}

--- a/api/turing/config/example.yaml
+++ b/api/turing/config/example.yaml
@@ -13,6 +13,9 @@ AuthConfig:
   Enabled: false
   # ORY Keto auth server URL: https://github.com/ory/keto
   URL: http://example.com/auth
+  # Whether or not local caching of authz responses should be enabled
+  Caching:
+    Enabled: false
 
 # Batch ensembler job configurations
 BatchEnsemblingConfig:

--- a/api/turing/config/testdata/config-1.yaml
+++ b/api/turing/config/testdata/config-1.yaml
@@ -5,6 +5,8 @@ AllowedOrigins:
 AuthConfig:
   Enabled: true
   URL: http://example.com
+  Caching:
+    Enabled: false
 DbConfig:
   Host: "127.0.0.1"
   User: dbuser

--- a/api/turing/middleware/authorization.go
+++ b/api/turing/middleware/authorization.go
@@ -96,7 +96,19 @@ func (a *Authorizer) FilterAuthorizedProjects(
 }
 
 func getResourceFromPath(path string, prefix string) string {
-	return strings.Replace(strings.TrimPrefix(strings.TrimPrefix(path, prefix), "/"), "/", ":", -1)
+	// Current paths registered in Turing are of the following formats:
+	// - /experiment-engines/**
+	// - /projects/{project_id}/**
+	//
+	// Given this, we only care about the permissions up-to 2 levels deep. The rationale is that
+	// if a user has READ/WRITE permissions on /projects/{project_id}, they would also have the same
+	// permissions on all its sub-resources. Thus, trimming the resource identifier to aid quicker
+	// authz matching and to efficiently make use of the in-memory authz cache, if enabled.
+	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	if len(parts) > 1 {
+		parts = parts[:2]
+	}
+	return strings.Join(parts, ":")
 }
 
 func getActionFromMethod(method string) string {

--- a/api/turing/server/application.go
+++ b/api/turing/server/application.go
@@ -81,7 +81,15 @@ func Run() {
 	apiPathPrefix := "/v1"
 	if cfg.AuthConfig.Enabled {
 		// Use product mlp as the policies are shared across the mlp products.
-		authEnforcer, err := enforcer.NewEnforcerBuilder().Product("mlp").URL(cfg.AuthConfig.URL).Build()
+		enforcerCfg := enforcer.NewEnforcerBuilder().URL(cfg.AuthConfig.URL).Product("mlp")
+		if cfg.AuthConfig.Caching.Enabled {
+			enforcerCfg = enforcerCfg.WithCaching(
+				cfg.AuthConfig.Caching.KeyExpirySeconds,
+				cfg.AuthConfig.Caching.CacheCleanUpIntervalSeconds,
+			)
+		}
+		authEnforcer, err := enforcerCfg.Build()
+
 		if err != nil {
 			log.Panicf("Failed initializing authorization enforcer %v", err)
 		}


### PR DESCRIPTION
This PR largely replicates the changes for the API in https://github.com/caraml-dev/mlp/pull/87, to have the option of caching authz responses. As a part of this implementation, the API dependency on MLP has been upgraded.