### PR TITLE
Bugfix: Add image building job deletion delay

### DIFF
--- a/api/turing/config/config.go
+++ b/api/turing/config/config.go
@@ -58,7 +58,7 @@ func (qty *Quantity) MarshalJSON() ([]byte, error) {
 
 type EngineConfig map[string]interface{}
 
-// EnvironmentConfig is a abridged version of
+// EnvironmentConfig is an abridged version of
 // https://github.dev/caraml-dev/merlin/blob/98ada0d3aa8de30d73e441d3fd1000fe5d5ac266/api/config/environment.go#L26
 // Only requires Name and K8sConfig
 // This struct should be removed when Environments API is moved from Merlin to MLP

--- a/api/turing/imagebuilder/imagebuilder.go
+++ b/api/turing/imagebuilder/imagebuilder.go
@@ -228,7 +228,7 @@ func (ib *imageBuilder) waitForJobToBeDeleted(job *apibatchv1.Job) error {
 		case <-ticker.C:
 			_, err := ib.clusterController.GetJob(context.Background(), ib.imageBuildingConfig.BuildNamespace, job.Name)
 			if err != nil {
-				if !kerrors.IsNotFound(err) {
+				if kerrors.IsNotFound(err) {
 					return nil
 				}
 				log.Errorf("unable to get job status for job %s: %v", job.Name, err)

--- a/api/turing/imagebuilder/imagebuilder.go
+++ b/api/turing/imagebuilder/imagebuilder.go
@@ -44,7 +44,7 @@ type JobStatus int
 
 const (
 	// jobDeletionTimeoutInSeconds is the maximum time to wait for a job to be deleted from a cluster
-	jobDeletionTimeoutInSeconds = 10
+	jobDeletionTimeoutInSeconds = 30
 	// jobDeletionTickDurationInMilliseconds is the interval at which the API server checks if a job has been deleted
 	jobDeletionTickDurationInMilliseconds = 100
 	// jobCompletionTickDurationInSeconds is the interval at which the API server checks if a job has completed

--- a/api/turing/imagebuilder/imagebuilder_test.go
+++ b/api/turing/imagebuilder/imagebuilder_test.go
@@ -229,7 +229,21 @@ func TestBuildPyFuncEnsemblerJobImage(t *testing.T) {
 					nil,
 				).Once()
 
-				// Second time it's called
+				// Second time GetJob is called
+				ctlr.On(
+					"GetJob",
+					mock.Anything,
+					mock.Anything,
+					mock.Anything,
+				).Return(
+					nil,
+					k8serrors.NewNotFound(
+						schema.GroupResource{},
+						fmt.Sprintf("batch-%s-%s-%d-%s", projectName, modelName, modelVersion, runID[:5]),
+					),
+				).Once()
+
+				// Third time it's called
 				ctlr.On(
 					"GetJob",
 					mock.Anything,
@@ -492,7 +506,21 @@ func TestBuildPyFuncEnsemblerServiceImage(t *testing.T) {
 					nil,
 				).Once()
 
-				// Second time it's called
+				// Second time GetJob is called
+				ctlr.On(
+					"GetJob",
+					mock.Anything,
+					mock.Anything,
+					mock.Anything,
+				).Return(
+					nil,
+					k8serrors.NewNotFound(
+						schema.GroupResource{},
+						fmt.Sprintf("service-builder-%s-%s-%d-%s", projectName, modelName, modelVersion, runID[:5]),
+					),
+				).Once()
+
+				// Third time it's called
 				ctlr.On(
 					"GetJob",
 					mock.Anything,


### PR DESCRIPTION
## Context
As of present, when the Turing API server triggers an image building job as part of launching a batch ensembling job/service, it checks for the presence of an existing image building job in the cluster with the same name. The status of the image building job found (if it is found), corresponds to a variety of situations:
- Found; running -> an existing image building job is already taking place and still running -> wait for the job to complete
- Found; failed -> an existing image building job has failed -> delete the old job -> begin a new one
- Not found -> begin a new one

In particular, we're interested in the **_second_** scenario, where there a new job is triggered right after the deletion of the old (failed) run (see [this](https://github.com/caraml-dev/turing/blob/33388a254167964c12d71f3b60b05475c49353d3/api/turing/imagebuilder/imagebuilder.go#LL159C1-L159C1) for more details): 

```go
err = ib.clusterController.DeleteJob(context.Background(), ib.imageBuildingConfig.BuildNamespace, job.Name)
if err != nil {
	log.Errorf("error deleting job: %v", err)
	return "", ErrDeleteFailedJob
}

job, err = ib.createKanikoJob(kanikoJobName, imageRef, request.ArtifactURI, request.BuildLabels,
	request.EnsemblerFolder, request.BaseImageRefTag)
if err != nil {
	log.Errorf("unable to build image %s, error: %v", imageRef, err)
	return "", ErrUnableToBuildImage
}
```

A potential problem can occur whereby the creation of the new job happens _too quickly_ after the deletion of the job, due to the k8s resources having insufficient time to be removed from the cluster (the kube API server would return an error saying that the creation of the new job has failed due to the existence of another job with the very same name). When this happens, the (new) image building job fails immediately.

This PR thus introduces a new method to wait for the deletion to be complete before proceeding with the creation of another image builder job.

## Main Modifications
- `api/turing/imagebuilder/imagebuilder.go` - Addition of an additional helper method to wait for image building jobs to be completely removed from the cluster