### PR TITLE
Fix ensembler deletion UI bugs

### DIFF
--- a/ui/src/ensembler/components/modal/DeleteEnsemblerModal.js
+++ b/ui/src/ensembler/components/modal/DeleteEnsemblerModal.js
@@ -70,9 +70,9 @@ export const DeleteEnsemblerModal = ({
           {canDeleteEnsembler ? (
             <div>
               <p>
-              You are about to delete Ensembler <b>{ensembler.name}</b>. This action cannot be undone. 
+              You are about to delete the Ensembler <b>{ensembler.name}</b>. This action <b>cannot</b> be undone.
               </p>
-              To confirm, please type "<b>{ensembler.name}</b>" in the box below
+              To confirm, please type "<b>{ensembler.name}</b>" in the box below:
               <EuiFieldText     
                 fullWidth            
                 placeholder={ensembler.name}
@@ -80,16 +80,14 @@ export const DeleteEnsemblerModal = ({
                 onChange={(e) => setDeleteConfirmation(e.target.value)}
                 isInvalid={deleteConfirmation !== ensembler.name} />              
             </div>
-          ) : ensemblerUsedByCurrentRouterVersion ? (
-            <div>
-              You cannot delete this ensembler because it is associated with a router version that is currently being used by a router
-              <br/> <br/> If you still wish to delete this ensembler, please <b>Deploy</b> another version on this router.
-            </div>
           ) : (
             <div>
-              You cannot delete this ensembler because there are <b>Active Router Versions</b> or <b>Ensembling Jobs</b> that use this ensembler. 
-              <br/> <br/> If you still wish to delete this ensembler, please <b>Undeploy</b> router versions and <b>Terminate</b> ensembling jobs that use this ensembler.
-            </div> 
+              You cannot delete this ensembler because it is:
+              <ul>
+                <li>associated with one or more router versions <b>currently</b> used by one or more routers, and/or</li>
+                <li>used by one or more <b>Active Router Versions</b> or <b>Ensembling Jobs</b></li>
+              </ul>
+            </div>
           )}
           {/* Only show The Ensembling Table if ensembler is not used by current router version */}
           {!ensemblerUsedByCurrentRouterVersion && (

--- a/ui/src/ensembler/components/modal/DeleteEnsemblerModal.js
+++ b/ui/src/ensembler/components/modal/DeleteEnsemblerModal.js
@@ -61,7 +61,7 @@ export const DeleteEnsemblerModal = ({
     <ConfirmationModal
       title="Delete Ensembler"
       onCancel={() => modalClosed()}
-      onConfirm={submitForm}
+      onConfirm={(arg) => {submitForm(arg); modalClosed()}}
       isLoading={isLoading}
       content={
         <div>

--- a/ui/src/ensembler/components/modal/DeleteEnsemblerModal.js
+++ b/ui/src/ensembler/components/modal/DeleteEnsemblerModal.js
@@ -84,8 +84,11 @@ export const DeleteEnsemblerModal = ({
             <div>
               You cannot delete this ensembler because it is:
               <ul>
-                <li>associated with one or more router versions <b>currently</b> used by one or more routers, and/or</li>
-                <li>used by one or more <b>Active Router Versions</b> or <b>Ensembling Jobs</b></li>
+                {ensemblerUsedByCurrentRouterVersion &&
+                  <li>associated with one or more router versions <b>currently</b> used by one or more routers
+                    {ensemblerUsedByActiveRouterVersion && ", and"}</li>}
+                {ensemblerUsedByActiveRouterVersion &&
+                  <li>used by one or more <b>Active Router Versions</b> or <b>Ensembling Jobs</b></li>}
               </ul>
             </div>
           )}

--- a/ui/src/ensembler/components/modal/DeleteEnsemblerModal.js
+++ b/ui/src/ensembler/components/modal/DeleteEnsemblerModal.js
@@ -54,6 +54,8 @@ export const DeleteEnsemblerModal = ({
   const modalClosed = () => {
     setCanDeleteEnsembler(true)
     setEnsemblerUsedByCurrentRouterVersion(false)
+    setEnsemblerUsedByActiveRouterVersion(false)
+    setEnsemblerUsedByActiveEnsemblingJob(false)
     setDeleteConfirmation("")
   }
 

--- a/ui/src/ensembler/components/table/ListEnsemblingJobsForEnsemblerTable.js
+++ b/ui/src/ensembler/components/table/ListEnsemblingJobsForEnsemblerTable.js
@@ -107,7 +107,7 @@ export const ListEnsemblingJobsForEnsemblerTable = ({
         <div>
           <br/>
           This Ensembler is used by {results.totalActiveCount} <b>Active Ensembling Job{results.totalActiveCount > 1 && "s"}</b>.
-          If any ensembling jobs are in the terminating state, please wait until they are complete to delete this ensembler.
+          If any ensembling jobs are in the terminating state, please wait until they are terminated to delete this ensembler.
           <EuiBasicTable
             items={results.activeItems}
             loading={!isLoaded}

--- a/ui/src/ensembler/components/table/ListEnsemblingJobsForEnsemblerTable.js
+++ b/ui/src/ensembler/components/table/ListEnsemblingJobsForEnsemblerTable.js
@@ -93,7 +93,8 @@ export const ListEnsemblingJobsForEnsemblerTable = ({
       {canDeleteEnsembler ? ( results.totalInactiveCount > 0 && (
         <div>
           <br/>
-          <p>Deleting this Ensembler will also delete {results.totalInactiveCount} <b>Failed</b> or <b>Completed</b> Ensembling Jobs that use this Ensembler </p>
+          Deleting this Ensembler will also delete {results.totalInactiveCount} <b>Failed</b> or <b>Completed</b>
+          &nbsp;Ensembling Job{results.totalInactiveCount > 1 && "s"} that use{results.totalInactiveCount === 1 && "s"} this Ensembler:
           <EuiBasicTable
             items={results.inactiveItems}
             loading={!isLoaded}
@@ -105,8 +106,8 @@ export const ListEnsemblingJobsForEnsemblerTable = ({
       )) : ( results.totalActiveCount > 0 && (
         <div>
           <br/>
-          <p>This Ensembler is being used by {results.totalActiveCount} <b>Active Ensembling Jobs</b>. 
-          If the ensembling jobs are in terminating state, please wait until the process complete to delete this ensembler</p>
+          This Ensembler is used by {results.totalActiveCount} <b>Active Ensembling Job{results.totalActiveCount > 1 && "s"}</b>.
+          If any ensembling jobs are in the terminating state, please wait until they are complete to delete this ensembler.
           <EuiBasicTable
             items={results.activeItems}
             loading={!isLoaded}
@@ -114,6 +115,7 @@ export const ListEnsemblingJobsForEnsemblerTable = ({
             responsive={true}
             tableLayout="auto"
           />
+          If you wish to delete this ensembler, please <b>terminate</b> {results.totalActiveCount > 1 ? "these ensembling jobs" : "this ensembling job"}.
         </div>
       ))}
     </Fragment>

--- a/ui/src/ensembler/components/table/ListRouterVersionsForEnsemblerTable.js
+++ b/ui/src/ensembler/components/table/ListRouterVersionsForEnsemblerTable.js
@@ -51,6 +51,9 @@ export const ListRouterVersionsForEnsemblerTable = ({
   useEffect(() => {
     if (results.activeItems.length > 0){
       setEnsemblerUsedByActiveRouterVersion(true)
+      // If there is an active router version using this ensembler, it is definitely also a current router version using
+      // this ensembler
+      setEnsemblerUsedByCurrentRouterVersion(true)
     } else {
       if (currentRouterVersion.isLoaded && !currentRouterVersion.error) {
         if (currentRouterVersion.data.length > 0){
@@ -115,7 +118,7 @@ export const ListRouterVersionsForEnsemblerTable = ({
     </EuiCallOut>
   ) : (
     <Fragment>
-      {ensemblerUsedByCurrentRouterVersion ? (
+      {(ensemblerUsedByCurrentRouterVersion && results.totalActiveCount === 0) ? (
         currentRouterVersion.data.length > 0 && (
         <div>
           <br/>

--- a/ui/src/jobs/components/modal/DeleteJobModal.js
+++ b/ui/src/jobs/components/modal/DeleteJobModal.js
@@ -45,7 +45,8 @@ export const DeleteJobModal = ({
   return (
     <ConfirmationModal
       title={isActiveJobStatus(job.status) ? 'Delete Ensembling Jobs' : 'Terminate Ensembling Jobs'}
-      onConfirm={submitForm}
+      onCancel={() => setDeleteConfirmation("")}
+      onConfirm={(arg) => {submitForm(arg); setDeleteConfirmation("")}}
       isLoading={isLoading}
       disabled={deleteConfirmation !== job.name}
       content={

--- a/ui/src/jobs/list/ListEnsemblingJobsTable.js
+++ b/ui/src/jobs/list/ListEnsemblingJobsTable.js
@@ -158,18 +158,17 @@ export const ListEnsemblingJobsTable = ({
                 <EuiText size="xs">Monitoring</EuiText>
               </EuiButtonEmpty>
             </EuiFlexItem>
-              {item.status !== "terminating" && (
-              <EuiFlexItem grow={false} >
-                  <EuiButtonEmpty
-                    onClick={() => onDeleteJob(item)}
-                    color={"danger"}
-                    iconType={isActiveJobStatus(item.status) ? "trash" : "minusInCircle" }
-                    iconSide="left"
-                    size="xs">
-                    <EuiText size="xs"> {isActiveJobStatus(item.status) ? "Delete" : "Terminate" } </EuiText>
-                  </EuiButtonEmpty>
-              </EuiFlexItem>
-              )}
+            <EuiFlexItem grow={false} >
+                <EuiButtonEmpty
+                  onClick={() => onDeleteJob(item)}
+                  color={"danger"}
+                  iconType={isActiveJobStatus(item.status) ? "trash" : "minusInCircle" }
+                  iconSide="left"
+                  size="xs"
+                  isDisabled={item.status === "terminating"}>
+                  <EuiText size="xs"> {isActiveJobStatus(item.status) ? "Delete" : "Terminate" } </EuiText>
+                </EuiButtonEmpty>
+            </EuiFlexItem>
           </EuiFlexItem>
         </EuiFlexGroup>
       ),


### PR DESCRIPTION
## Context
Similar to PR #348 which introduced some UI fixes to the ensembler deletion workflow (which itself had been introduced in PR #329), this PR acts as a follow up to implement some additional minor fixes to the UI for the bugs below:
- when deleting multiple ensemblers in a row, the confirmation text box in the pop-up gets pre-filled with the ensembler name from the previous ensembler that had been deleted
![image](https://github.com/caraml-dev/turing/assets/36802364/86037e1d-0eb9-4074-b352-aa4f0dd16eca)
- when opening and closing the deletion pop-up multiple times in a row (without actually deleting the ensembler), the information shown in the pop-up is not consistent (see the video at the bottom of this description for an illustration).

Besides these bug fixes, some other non-bug related improvements have been introduced:
- some minor changes to the formatting of the pop messages to better reflect the different types/quantities of router/router versions/ensembling jobs returned (see https://github.com/caraml-dev/turing/pull/352#issuecomment-1641552190)
- a modification to a change introduced in PR #348 whereby instead of hiding the 'Terminate/Delete' button if an ensembling job is in the 'terminating' state, we are now showing the button but greying that out instead

https://github.com/caraml-dev/turing/assets/36802364/9fa7e60d-1faf-47a5-9796-aebd47c95d45



