### PR TITLE
fix: Add precautionary logic for PDB

### DIFF
--- a/api/turing/service/router_deployment_service.go
+++ b/api/turing/service/router_deployment_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"strings"
 	"sync"
@@ -748,8 +749,26 @@ func (ds *deploymentService) createPodDisruptionBudgets(
 ) []*cluster.PodDisruptionBudget {
 	pdbs := []*cluster.PodDisruptionBudget{}
 
+	// Only create PDB if: ceil(minReplica * minAvailablePercent) < minReplica
+	// If not, the replicas may be unable to be removed.
+	// Note that we only care about minReplica here because, for active replicas > minReplica,
+	// the condition will be satisfied if it was satisfied for the minReplica case.
+
+	var minAvailablePercent float64
+	if ds.pdbConfig.MinAvailablePercentage != nil {
+		minAvailablePercent = float64(*ds.pdbConfig.MinAvailablePercentage) / 100.0
+	} else if ds.pdbConfig.MaxUnavailablePercentage != nil {
+		minAvailablePercent = float64(100-*ds.pdbConfig.MaxUnavailablePercentage) / 100.0
+	} else {
+		// PDB config is not set properly, we can't apply it.
+		return pdbs
+	}
+
 	// Enricher's PDB
-	if routerVersion.Enricher != nil {
+	if routerVersion.Enricher != nil &&
+		routerVersion.Enricher.ResourceRequest != nil &&
+		math.Ceil(float64(routerVersion.Enricher.ResourceRequest.MinReplica)*
+			minAvailablePercent) < float64(routerVersion.Enricher.ResourceRequest.MinReplica) {
 		enricherPdb := ds.svcBuilder.NewPodDisruptionBudget(
 			routerVersion,
 			project,
@@ -759,8 +778,16 @@ func (ds *deploymentService) createPodDisruptionBudgets(
 		pdbs = append(pdbs, enricherPdb)
 	}
 
-	// Ensembler's PDB
-	if routerVersion.Enricher != nil {
+	// Ensembler's PDB - create for Docker / Pyfunc ensemblers only
+	if routerVersion.Ensembler != nil &&
+		((routerVersion.Ensembler.Type == models.EnsemblerDockerType &&
+			routerVersion.Ensembler.DockerConfig.ResourceRequest != nil &&
+			math.Ceil(float64(routerVersion.Ensembler.DockerConfig.ResourceRequest.MinReplica)*
+				minAvailablePercent) < float64(routerVersion.Ensembler.DockerConfig.ResourceRequest.MinReplica)) ||
+			(routerVersion.Ensembler.Type == models.EnsemblerPyFuncType &&
+				routerVersion.Ensembler.PyfuncConfig.ResourceRequest != nil &&
+				math.Ceil(float64(routerVersion.Ensembler.PyfuncConfig.ResourceRequest.MinReplica)*
+					minAvailablePercent) < float64(routerVersion.Ensembler.PyfuncConfig.ResourceRequest.MinReplica))) {
 		ensemblerPdb := ds.svcBuilder.NewPodDisruptionBudget(
 			routerVersion,
 			project,
@@ -771,13 +798,17 @@ func (ds *deploymentService) createPodDisruptionBudgets(
 	}
 
 	// Router's PDB
-	routerPdb := ds.svcBuilder.NewPodDisruptionBudget(
-		routerVersion,
-		project,
-		servicebuilder.ComponentTypes.Router,
-		ds.pdbConfig,
-	)
-	pdbs = append(pdbs, routerPdb)
+	if routerVersion.ResourceRequest != nil &&
+		math.Ceil(float64(routerVersion.ResourceRequest.MinReplica)*
+			minAvailablePercent) < float64(routerVersion.ResourceRequest.MinReplica) {
+		routerPdb := ds.svcBuilder.NewPodDisruptionBudget(
+			routerVersion,
+			project,
+			servicebuilder.ComponentTypes.Router,
+			ds.pdbConfig,
+		)
+		pdbs = append(pdbs, routerPdb)
+	}
 
 	return pdbs
 }

--- a/api/turing/service/router_deployment_service.go
+++ b/api/turing/service/router_deployment_service.go
@@ -780,11 +780,11 @@ func (ds *deploymentService) createPodDisruptionBudgets(
 
 	// Ensembler's PDB - create for Docker / Pyfunc ensemblers only
 	if routerVersion.Ensembler != nil &&
-		((routerVersion.Ensembler.Type == models.EnsemblerDockerType &&
+		((routerVersion.Ensembler.DockerConfig != nil &&
 			routerVersion.Ensembler.DockerConfig.ResourceRequest != nil &&
 			math.Ceil(float64(routerVersion.Ensembler.DockerConfig.ResourceRequest.MinReplica)*
 				minAvailablePercent) < float64(routerVersion.Ensembler.DockerConfig.ResourceRequest.MinReplica)) ||
-			(routerVersion.Ensembler.Type == models.EnsemblerPyFuncType &&
+			(routerVersion.Ensembler.PyfuncConfig != nil &&
 				routerVersion.Ensembler.PyfuncConfig.ResourceRequest != nil &&
 				math.Ceil(float64(routerVersion.Ensembler.PyfuncConfig.ResourceRequest.MinReplica)*
 					minAvailablePercent) < float64(routerVersion.Ensembler.PyfuncConfig.ResourceRequest.MinReplica))) {

--- a/api/turing/service/router_deployment_service_test.go
+++ b/api/turing/service/router_deployment_service_test.go
@@ -365,16 +365,6 @@ func TestDeployEndpoint(t *testing.T) {
 		},
 	})
 	controller.AssertCalled(t, "ApplyPodDisruptionBudget", mock.Anything, testNamespace, cluster.PodDisruptionBudget{
-		Name:                   "test-svc-turing-enricher-1-pdb",
-		Namespace:              testNamespace,
-		MinAvailablePercentage: &defaultMinAvailablePercentage,
-		Selector: &apimetav1.LabelSelector{
-			MatchLabels: map[string]string{
-				"app": "test-svc-turing-enricher-1-0",
-			},
-		},
-	})
-	controller.AssertCalled(t, "ApplyPodDisruptionBudget", mock.Anything, testNamespace, cluster.PodDisruptionBudget{
 		Name:                   "test-svc-turing-ensembler-1-pdb",
 		Namespace:              testNamespace,
 		MinAvailablePercentage: &defaultMinAvailablePercentage,
@@ -384,7 +374,7 @@ func TestDeployEndpoint(t *testing.T) {
 			},
 		},
 	})
-	controller.AssertNumberOfCalls(t, "ApplyPodDisruptionBudget", 3)
+	controller.AssertNumberOfCalls(t, "ApplyPodDisruptionBudget", 2)
 
 	// Verify endpoint for upi routers
 	routerVersion.Protocol = routerConfig.UPI
@@ -409,6 +399,7 @@ func TestDeleteEndpoint(t *testing.T) {
 	testEnv := "test-env"
 	testNs := "test-namespace"
 	timeout := time.Second * 5
+	defaultMinAvailablePercentage := 10
 
 	// Create mock controller
 	controller := &mocks.Controller{}
@@ -447,6 +438,10 @@ func TestDeleteEndpoint(t *testing.T) {
 			testEnv: controller,
 		},
 		svcBuilder: svcBuilder,
+		pdbConfig: config.PodDisruptionBudgetConfig{
+			Enabled:                true,
+			MinAvailablePercentage: &defaultMinAvailablePercentage,
+		},
 	}
 
 	eventsCh := NewEventChannel()
@@ -479,7 +474,7 @@ func TestDeleteEndpoint(t *testing.T) {
 	controller.AssertCalled(t, "DeletePersistentVolumeClaim", mock.Anything, "pvc", testNs, false)
 	controller.AssertCalled(t, "DeletePodDisruptionBudget", mock.Anything, testNs, mock.Anything)
 	controller.AssertNumberOfCalls(t, "DeleteKnativeService", 3)
-	controller.AssertNumberOfCalls(t, "DeletePodDisruptionBudget", 3)
+	controller.AssertNumberOfCalls(t, "DeletePodDisruptionBudget", 2)
 }
 
 func TestBuildEnsemblerServiceImage(t *testing.T) {

--- a/api/turing/service/router_deployment_service_test.go
+++ b/api/turing/service/router_deployment_service_test.go
@@ -597,7 +597,7 @@ func TestCreatePodDisruptionBudgets(t *testing.T) {
 				MinAvailablePercentage: &twenty,
 			},
 			expected: []*cluster.PodDisruptionBudget{
-				&cluster.PodDisruptionBudget{
+				{
 					Name:                   "test-turing-enricher-3-pdb",
 					Namespace:              "ns",
 					Labels:                 testRouterLabels,
@@ -608,7 +608,7 @@ func TestCreatePodDisruptionBudgets(t *testing.T) {
 						},
 					},
 				},
-				&cluster.PodDisruptionBudget{
+				{
 					Name:                   "test-turing-ensembler-3-pdb",
 					Namespace:              "ns",
 					Labels:                 testRouterLabels,
@@ -619,7 +619,7 @@ func TestCreatePodDisruptionBudgets(t *testing.T) {
 						},
 					},
 				},
-				&cluster.PodDisruptionBudget{
+				{
 					Name:                   "test-turing-router-3-pdb",
 					Namespace:              "ns",
 					Labels:                 testRouterLabels,
@@ -659,7 +659,7 @@ func TestCreatePodDisruptionBudgets(t *testing.T) {
 				MaxUnavailablePercentage: &eighty,
 			},
 			expected: []*cluster.PodDisruptionBudget{
-				&cluster.PodDisruptionBudget{
+				{
 					Name:                     "test-turing-enricher-3-pdb",
 					Namespace:                "ns",
 					Labels:                   testRouterLabels,
@@ -670,7 +670,7 @@ func TestCreatePodDisruptionBudgets(t *testing.T) {
 						},
 					},
 				},
-				&cluster.PodDisruptionBudget{
+				{
 					Name:                     "test-turing-ensembler-3-pdb",
 					Namespace:                "ns",
 					Labels:                   testRouterLabels,
@@ -681,7 +681,7 @@ func TestCreatePodDisruptionBudgets(t *testing.T) {
 						},
 					},
 				},
-				&cluster.PodDisruptionBudget{
+				{
 					Name:                     "test-turing-router-3-pdb",
 					Namespace:                "ns",
 					Labels:                   testRouterLabels,
@@ -716,7 +716,7 @@ func TestCreatePodDisruptionBudgets(t *testing.T) {
 				MinAvailablePercentage: &twenty,
 			},
 			expected: []*cluster.PodDisruptionBudget{
-				&cluster.PodDisruptionBudget{
+				{
 					Name:                   "test-turing-ensembler-3-pdb",
 					Namespace:              "ns",
 					Labels:                 testRouterLabels,


### PR DESCRIPTION
PDB support for router components was introduced in https://github.com/caraml-dev/turing/pull/346. This PR fixes some bugs / corner cases:
* For ensembler, PDB should only be created for Docker / Pyfunc types (as Standard ensembler is embedded in the router deployment)
* Do not create PDB if the min replica is too low, which can prevent node drain. See related Merlin PR for more details: https://github.com/caraml-dev/merlin/pull/436