### PR TITLE
fix: Invert logic of isActiveJobStatus helper function

### DIFF
--- a/ui/src/jobs/components/modal/DeleteJobModal.js
+++ b/ui/src/jobs/components/modal/DeleteJobModal.js
@@ -5,6 +5,7 @@ import { useTuringApi } from "../../../hooks/useTuringApi";
 import { ConfirmationModal } from "../../../components/confirmation_modal/ConfirmationModal";
 import { isEmpty } from "../../../utils/object";
 import { EuiFieldText } from "@elastic/eui";
+import { isActiveJobStatus } from "../../../services/job/JobStatus";
 
 export const DeleteJobModal = ({
   onSuccess,
@@ -38,13 +39,9 @@ export const DeleteJobModal = ({
     }
   }, [isLoaded, error, job, onSuccess, closeModal]);
 
-  const isActiveJobStatus = function(jobStatus) {
-    return ["failed", "failed_submission", "failed_building", "completed"].includes(jobStatus);
-  }
-
   return (
     <ConfirmationModal
-      title={isActiveJobStatus(job.status) ? 'Delete Ensembling Jobs' : 'Terminate Ensembling Jobs'}
+      title={isActiveJobStatus(job.status) ? "Terminate Ensembling Jobs" : "Delete Ensembling Jobs" }
       onCancel={() => setDeleteConfirmation("")}
       onConfirm={(arg) => {submitForm(arg); setDeleteConfirmation("")}}
       isLoading={isLoading}
@@ -63,7 +60,7 @@ export const DeleteJobModal = ({
             isInvalid={deleteConfirmation !== job.name} />   
         </div>
       }
-      confirmButtonText={isActiveJobStatus(job.status) ? 'Delete' : 'Terminate'}
+      confirmButtonText={isActiveJobStatus(job.status) ? "Terminate" : "Delete"}
       confirmButtonColor="danger">
       {(onSubmit) =>
         (deleteJobRef.current = openModal(onSubmit)) &&

--- a/ui/src/jobs/list/ListEnsemblingJobsTable.js
+++ b/ui/src/jobs/list/ListEnsemblingJobsTable.js
@@ -17,7 +17,7 @@ import { useNavigate } from "react-router-dom";
 import { useConfig } from "../../config";
 import moment from "moment";
 import { DeploymentStatusHealth } from "../../components/status_health/DeploymentStatusHealth";
-import { JobStatus } from "../../services/job/JobStatus";
+import { isActiveJobStatus, JobStatus } from "../../services/job/JobStatus";
 import EnsemblersContext from "../../providers/ensemblers/context";
 import { DateFromNow } from "@caraml-dev/ui-lib";
 import { DeleteJobModal } from "../components/modal/DeleteJobModal";
@@ -67,10 +67,6 @@ export const ListEnsemblingJobsTable = ({
 
   const onDeleteJob = (job) => {
     deleteJobRef.current(job)
-  }
-  
-  const isActiveJobStatus = function(jobStatus) {
-    return ["pending", "building", "running", "terminating"].includes(jobStatus);
   }
 
   const columns = [

--- a/ui/src/jobs/list/ListEnsemblingJobsTable.js
+++ b/ui/src/jobs/list/ListEnsemblingJobsTable.js
@@ -70,8 +70,8 @@ export const ListEnsemblingJobsTable = ({
   }
   
   const isActiveJobStatus = function(jobStatus) {
-    return ["failed", "failed_submission", "failed_building", "completed"].includes(jobStatus);
-}
+    return ["pending", "building", "running", "terminating"].includes(jobStatus);
+  }
 
   const columns = [
     {
@@ -159,15 +159,15 @@ export const ListEnsemblingJobsTable = ({
               </EuiButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false} >
-                <EuiButtonEmpty
-                  onClick={() => onDeleteJob(item)}
-                  color={"danger"}
-                  iconType={isActiveJobStatus(item.status) ? "trash" : "minusInCircle" }
-                  iconSide="left"
-                  size="xs"
-                  isDisabled={item.status === "terminating"}>
-                  <EuiText size="xs"> {isActiveJobStatus(item.status) ? "Delete" : "Terminate" } </EuiText>
-                </EuiButtonEmpty>
+              <EuiButtonEmpty
+                onClick={() => onDeleteJob(item)}
+                color={"danger"}
+                iconType={isActiveJobStatus(item.status) ? "minusInCircle" : "trash"  }
+                iconSide="left"
+                size="xs"
+                isDisabled={item.status === "terminating"}>
+                <EuiText size="xs"> {isActiveJobStatus(item.status) ? "Terminate" : "Delete" } </EuiText>
+              </EuiButtonEmpty>
             </EuiFlexItem>
           </EuiFlexItem>
         </EuiFlexGroup>

--- a/ui/src/services/job/JobStatus.js
+++ b/ui/src/services/job/JobStatus.js
@@ -46,3 +46,7 @@ export const JobStatus = Enum({
     iconType: "cross",
   }),
 });
+
+export const isActiveJobStatus = function(jobStatus) {
+  return ["pending", "building", "running", "terminating"].includes(jobStatus);
+};


### PR DESCRIPTION
## Context
This context inverts the logic of the `isActiveJobStatus` helper function used in the UI, since its name doesn't really represent what it actually does (it actually does the inverse 👀)