### PR TITLE
docs: Reword certain parts of the ensembler deletion docs

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -31,10 +31,10 @@
     * [Deleting router versions](how-to/delete-a-router/delete-a-router-version.md)
     * [Deleting router versions from details page](how-to/delete-a-router/delete-a-router-version-from-details-page.md)
     * [Deleting routers](how-to/delete-a-router/delete-a-router.md)
-* [Deleting Ensemblers](how-to/delete-a-ensembler/README.md)
-    * [Deleting ensembler without related entity](how-to/delete-a-ensembler/delete-a-ensembler.md)
-    * [Deleting ensembler with related inactive entity](how-to/delete-a-ensembler/delete-a-ensembler-inactive.md)
-    * [Deleting ensembler with related active entity](how-to/delete-a-ensembler/delete-a-ensembler-active.md)
+* [Deleting Ensemblers](how-to/delete-an-ensembler/README.md)
+    * [Deleting ensemblers without related entities](how-to/delete-an-ensembler/delete-an-ensembler.md)
+    * [Deleting ensemblers with related inactive entities](how-to/delete-an-ensembler/delete-an-ensembler-inactive.md)
+    * [Deleting ensemblers with related active entities](how-to/delete-an-ensembler/delete-an-ensembler-active.md)
 
 ## Developer Guides
 * [Getting started](dev-docs/README.md)

--- a/docs/how-to/delete-an-ensembler/README.md
+++ b/docs/how-to/delete-an-ensembler/README.md
@@ -1,6 +1,6 @@
 # Deleting Ensembler
 
-An ensembler only can be deleted if it is not in active use in routers or ensembling jobs. Deleting an ensembler that is not in active use by any routers or ensembling jobs will result in the purging of the inactive related router version, inactive ensembling job, and ensembler metadata from turing database. This action is **irreversible**.
+An ensembler can only be deleted if it is not in active use by any routers or ensembling jobs. Deleting such an ensembler will result in the purging of all related inactive router versions and ensembling jobs, as well as the ensembler metadata from the Turing database. This action is **irreversible**.
 
 {% page-ref page="delete-an-ensembler.md" %}
 {% page-ref page="delete-an-ensembler-active.md" %}

--- a/docs/how-to/delete-an-ensembler/delete-an-ensembler-active.md
+++ b/docs/how-to/delete-an-ensembler/delete-an-ensembler-active.md
@@ -1,17 +1,15 @@
-# Deleting an Ensembler with related active entity
+# Deleting an Ensembler with related active entities
 
-An Ensembler only could be deleted if there are no active ensembling jobs or router versions that use the ensembler. This page shows the deletion of ensembler **with related active entity** (ensembling job and router version).
+This page describes the process of deleting ensemblers **with related active entities** (ensembling jobs and/or router versions).
 
-Ensembler with related active router versions or ensembling jobs can not be deleted. Ensembler that is currently used by a router also can not be deleted.
+Ensemblers with related active router versions or ensembling jobs cannot be deleted. Ensemblers that are currently used by any routers also cannot be deleted.
 
-Navigate to Ensemblers page
-
-Click on the delete button 
+Navigate to the Ensemblers page. Click on the delete button:
 
 ![](../../.gitbook/assets/ensembler_page.png)
 
-The ensembler can not be deleted since there are active router versions or ensembling jobs using the ensembler. Hence, the dialog will show the related entity that block the deletion process.
+The ensembler cannot be deleted since there are active router versions or ensembling jobs using the ensembler. Hence, the dialog will show the related entity that blocks the deletion process:
 
 ![](../../.gitbook/assets/delete_ensembler_modal_active.png)
 
-If you still wish to delete the ensembler, please follow notes on the dialog. Since there are multiple constraint for the ensembler deletion process.
+If you still wish to delete the ensembler, please follow the instructions shown in the dialog.

--- a/docs/how-to/delete-an-ensembler/delete-an-ensembler-inactive.md
+++ b/docs/how-to/delete-an-ensembler/delete-an-ensembler-inactive.md
@@ -1,22 +1,21 @@
-# Deleting an Ensembler with related inactive entity
+# Deleting an Ensembler with related inactive entities
 
-An Ensembler only could be deleted if there are no active ensembling jobs or router versions that use the ensembler. This page shows the deletion of ensembler **with related inactive entity** (ensembling job and router version).
+This page describes the process of deleting of ensemblers **with related inactive entities** (ensembling jobs and/or router versions).
 
-Deleting the ensembler will also delete any inactive entity related to the ensembler
+Deleting the ensembler will also delete any inactive entities related to the ensembler.
 
-Navigate to Ensemblers page
-
-Click on the delete button 
+Navigate to the Ensemblers page. Click on the delete button:
 
 ![](../../.gitbook/assets/ensembler_page.png)
 
-The Dialog will show related entity that are going to be deleted following the deletion of the ensembler. The router versions and the ensembling jobs shown on the popup will get deleted since both are inactive.
+The related router versions and the ensembling jobs shown in the dialog will get deleted together with the ensembler since they are inactive:
 
 ![](../../.gitbook/assets/delete_ensembler_modal_inactive.png)
 
-Please type the ensembler name for confirmation
+Type the ensembler's name in the text bar to confirm your decision:
+
 ![](../../.gitbook/assets/delete_ensembler_modal_inactive_filled.png)
 
-Once the specified ensembler has been successfully deleted, you will no longer be able to see the ensembler on the ensembler page.
+Once the specified ensembler has been successfully deleted, you will no longer be able to see the ensembler on the Ensemblers page:
 
 ![](../../.gitbook/assets/ensembler_page_empty.png)

--- a/docs/how-to/delete-an-ensembler/delete-an-ensembler.md
+++ b/docs/how-to/delete-an-ensembler/delete-an-ensembler.md
@@ -1,18 +1,16 @@
 # Deleting an Ensembler without any related entity
 
-An Ensembler only could be deleted if there are no active ensembling jobs or router versions that use the ensembler. This page shows the deletion of ensembler **without any related entity** (ensembling job and router version)
+This page describes the process of deleting an ensembler **without any related entities** (ensembling jobs or router versions).
 
-Navigate to Ensemblers page
-
-Click on the delete button 
+Navigate to the Ensemblers page. Click on the 'Delete' button:
 
 ![](../../.gitbook/assets/ensembler_page.png)
 
-Please type the ensembler name for confirmation
+Type the ensembler's name in the text bar to confirm your decision:
 
 ![](../../.gitbook/assets/delete_ensembler_modal_success.png)
 ![](../../.gitbook/assets/delete_ensembler_modal_success_filled.png)
 
-Once the specified ensembler has been successfully deleted, you will no longer be able to see the ensembler on the ensembler page.
+Once the specified ensembler has been successfully deleted, you will no longer be able to see the ensembler on the Ensemblers page:
 
 ![](../../.gitbook/assets/ensembler_page_empty.png)


### PR DESCRIPTION
## Context
This tiny-PR rewords certain parts of the ensembler deletion docs that were added in #329 to make them more consistent or to remove certain sentences that are repeated in various sections. There are also some changes to the sentences to make them simpler and more succinct.

## Modifications
- `docs/how-to/delete-an-ensembler/*` - Rewording of some parts of the documentation
