### PR TITLE
fix: Prevent calls to ensembling job service/controllers if batch ensembling is deactivated

### DIFF
--- a/api/turing/api/ensemblers_api.go
+++ b/api/turing/api/ensemblers_api.go
@@ -255,6 +255,11 @@ func (c EnsemblersController) checkCurrentRouterVersion(options EnsemblersPathOp
 }
 
 func (c EnsemblersController) checkActiveEnsemblingJob(options EnsemblersPathOptions) (int, error) {
+	// Batch ensembling is not enabled
+	if c.EnsemblingJobService == nil {
+		return http.StatusOK, nil
+	}
+
 	ensemblingJobActiveOption := service.EnsemblingJobListOptions{
 		EnsemblerID: options.EnsemblerID,
 		Statuses: []models.Status{
@@ -298,6 +303,11 @@ func (c EnsemblersController) deleteInactiveRouterVersion(options EnsemblersPath
 	return http.StatusOK, nil
 }
 func (c EnsemblersController) deleteInactiveEnsemblingJob(options EnsemblersPathOptions) (int, error) {
+	// Batch ensembling is not enabled
+	if c.EnsemblingJobService == nil {
+		return http.StatusOK, nil
+	}
+
 	ensemblingJobInactiveOption := service.EnsemblingJobListOptions{
 		EnsemblerID: options.EnsemblerID,
 		Statuses: []models.Status{

--- a/api/turing/api/ensemblers_api_test.go
+++ b/api/turing/api/ensemblers_api_test.go
@@ -912,7 +912,6 @@ func TestEnsemblerController_DeleteEnsembler(t *testing.T) {
 
 				return routerVersionSvc
 			},
-			ensemblingJobSvc: nil,
 			mlflowSvc: func() mlflow.Service {
 				mlflowSvc := &mlflowMock.Service{}
 				mlflowSvc.On("DeleteExperiment", mock.Anything, "1", true).Return(nil)
@@ -982,7 +981,7 @@ func TestEnsemblerController_DeleteEnsembler(t *testing.T) {
 				ensemblingJobSvc = tt.ensemblingJobSvc()
 			}
 			var routerVersionsSvc service.RouterVersionsService
-			if tt.ensemblingJobSvc != nil {
+			if tt.routerVersionsSvc != nil {
 				routerVersionsSvc = tt.routerVersionsSvc()
 			}
 

--- a/api/turing/api/ensemblers_api_test.go
+++ b/api/turing/api/ensemblers_api_test.go
@@ -889,6 +889,37 @@ func TestEnsemblerController_DeleteEnsembler(t *testing.T) {
 			},
 			expected: InternalServerError("failed to delete the ensembler", "failed to delete"),
 		},
+		"success | batch ensembling is not enabled": {
+			vars: RequestVars{
+				"project_id":   {"2"},
+				"ensembler_id": {"2"},
+			},
+			ensemblerSvc: func() service.EnsemblersService {
+				ensemblerSvc := &mocks.EnsemblersService{}
+				ensemblerSvc.
+					On("FindByID", models.ID(2), service.EnsemblersFindByIDOptions{
+						ProjectID: models.NewID(2),
+					}).
+					Return(original, nil)
+				ensemblerSvc.
+					On("Delete", original).
+					Return(nil)
+				return ensemblerSvc
+			},
+			routerVersionsSvc: func() service.RouterVersionsService {
+				routerVersionSvc := &mocks.RouterVersionsService{}
+				routerVersionSvc.On("ListRouterVersionsWithFilter", mock.Anything).Return([]*models.RouterVersion{}, nil)
+
+				return routerVersionSvc
+			},
+			ensemblingJobSvc: nil,
+			mlflowSvc: func() mlflow.Service {
+				mlflowSvc := &mlflowMock.Service{}
+				mlflowSvc.On("DeleteExperiment", mock.Anything, "1", true).Return(nil)
+				return mlflowSvc
+			},
+			expected: Ok(models.ID(2)),
+		},
 		"success": {
 			vars: RequestVars{
 				"project_id":   {"2"},

--- a/ui/src/ensembler/components/modal/DeleteEnsemblerModal.js
+++ b/ui/src/ensembler/components/modal/DeleteEnsemblerModal.js
@@ -7,6 +7,7 @@ import { isEmpty } from "../../../utils/object";
 import { ListEnsemblingJobsForEnsemblerTable } from "../table/ListEnsemblingJobsForEnsemblerTable";
 import { ListRouterVersionsForEnsemblerTable } from "../table/ListRouterVersionsForEnsemblerTable";
 import { EuiFieldText } from "@elastic/eui";
+import {useConfig} from "../../../config";
 
 export const DeleteEnsemblerModal = ({
   onSuccess,
@@ -22,6 +23,10 @@ export const DeleteEnsemblerModal = ({
 
   const [deleteConfirmation, setDeleteConfirmation] = useState('')
   const [ensembler = {}, openModal, closeModal] = useEnsemblerModal(closeModalRef);
+
+  const {
+    appConfig: { batchEnsemblingEnabled },
+  } = useConfig();
 
   useEffect(() => {
     // if ensembler is used by one of the component, immediately set can delete ensembler to false
@@ -93,7 +98,7 @@ export const DeleteEnsemblerModal = ({
             </div>
           )}
           {/* Only show The Ensembling Table if ensembler is not used by current router version */}
-          {!ensemblerUsedByCurrentRouterVersion && (
+          {!ensemblerUsedByCurrentRouterVersion && batchEnsemblingEnabled && (
             <ListEnsemblingJobsForEnsemblerTable 
               projectID={ensembler.project_id}
               ensemblerID={ensembler.id}


### PR DESCRIPTION
## Context
When an ensembler gets deleted, checks are performed to see if there are any associated ensembling jobs that use it. However, these checks are unnecessary and should not be performed if batch ensembling has been deactivated in the first place. Doing so triggers bugs and other errors because the ensembling job service or controllers wouldn't be initialised during start up of the Turing API server. 

This PR thus introduces some additional checks to ensure that these checks are skipped if batch ensembling is turned off, so as to prevent such bugs:
- on the UI level: prevent the ensembler deletion pop up from sending any requests to the Turing API server to retrieve a list of related ensembling jobs if batch ensembling is turned off
![image](https://github.com/caraml-dev/turing/assets/36802364/15cb9b38-4f61-43b5-9628-a69afc3f99b3)
- on the API level: prevent the delete ensembler handler from using the ensembling job service to retrieve ensembling jobs if batch ensembling is turned off