### PR TITLE
Add kaniko service account to image builder configs

### DIFF
--- a/api/turing/cluster/job.go
+++ b/api/turing/cluster/job.go
@@ -20,6 +20,7 @@ type Job struct {
 	SecretVolumes           []SecretVolume
 	TolerationName          *string
 	NodeSelector            map[string]string
+	ServiceAccount          string
 }
 
 // Build converts the spec into a Kubernetes spec
@@ -63,11 +64,12 @@ func (j *Job) Build() *batchv1.Job {
 					Annotations: j.Annotations,
 				},
 				Spec: corev1.PodSpec{
-					RestartPolicy: j.RestartPolicy,
-					Containers:    containers,
-					Volumes:       volumes,
-					Tolerations:   tolerations,
-					NodeSelector:  j.NodeSelector,
+					RestartPolicy:      j.RestartPolicy,
+					Containers:         containers,
+					Volumes:            volumes,
+					Tolerations:        tolerations,
+					NodeSelector:       j.NodeSelector,
+					ServiceAccountName: j.ServiceAccount,
 				},
 			},
 		},

--- a/api/turing/cluster/job_test.go
+++ b/api/turing/cluster/job_test.go
@@ -61,6 +61,7 @@ func TestJob(t *testing.T) {
 					NodeSelector: map[string]string{
 						"node-workload-type": "image",
 					},
+					ServiceAccountName: serviceAccountName,
 				},
 			},
 		},
@@ -87,6 +88,7 @@ func TestJob(t *testing.T) {
 		NodeSelector: map[string]string{
 			"node-workload-type": "image",
 		},
+		ServiceAccount: serviceAccountName,
 	}
 
 	assert.Equal(t, expected, *j.Build())

--- a/api/turing/config/config.go
+++ b/api/turing/config/config.go
@@ -204,6 +204,8 @@ type KanikoConfig struct {
 	Image string `validate:"required"`
 	// ImageVersion is the version tag of the Kaniko image
 	ImageVersion string `validate:"required"`
+	// Kaniko kubernetes service account
+	ServiceAccount string
 	// ResourceRequestsLimits is the resources required by Kaniko executor.
 	ResourceRequestsLimits ResourceRequestsLimits `validate:"required"`
 }

--- a/api/turing/imagebuilder/imagebuilder.go
+++ b/api/turing/imagebuilder/imagebuilder.go
@@ -8,6 +8,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/caraml-dev/turing/api/turing/cluster"
+	"github.com/caraml-dev/turing/api/turing/config"
+	"github.com/caraml-dev/turing/api/turing/log"
+	"github.com/caraml-dev/turing/api/turing/models"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/google"
@@ -18,11 +22,6 @@ import (
 	apicorev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
-
-	"github.com/caraml-dev/turing/api/turing/cluster"
-	"github.com/caraml-dev/turing/api/turing/config"
-	"github.com/caraml-dev/turing/api/turing/log"
-	"github.com/caraml-dev/turing/api/turing/models"
 )
 
 var (
@@ -277,6 +276,34 @@ func (ib *imageBuilder) createKanikoJob(
 		annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"] = "false"
 	}
 
+	var volumes []cluster.SecretVolume
+	var volumeMounts []cluster.VolumeMount
+	var envVars []cluster.Env
+
+	// If kaniko service account is not set, use kaniko secret
+	if ib.imageBuildingConfig.KanikoConfig.ServiceAccount == "" {
+		kanikoArgs = append(kanikoArgs,
+			fmt.Sprintf("--build-arg=GOOGLE_APPLICATION_CREDENTIALS=%s", kanikoSecretFilePath))
+		volumes = []cluster.SecretVolume{
+			{
+				Name:       kanikoSecretName,
+				SecretName: kanikoSecretName,
+			},
+		}
+		volumeMounts = []cluster.VolumeMount{
+			{
+				Name:      kanikoSecretName,
+				MountPath: kanikoSecretMountpath,
+			},
+		}
+		envVars = []cluster.Env{
+			{
+				Name:  googleApplicationEnvVarName,
+				Value: kanikoSecretFilePath,
+			},
+		}
+	}
+
 	job := cluster.Job{
 		Name:                    kanikoJobName,
 		Namespace:               ib.imageBuildingConfig.BuildNamespace,
@@ -294,19 +321,9 @@ func (ib *imageBuilder) createKanikoJob(
 					ib.imageBuildingConfig.KanikoConfig.Image,
 					ib.imageBuildingConfig.KanikoConfig.ImageVersion,
 				),
-				Args: kanikoArgs,
-				VolumeMounts: []cluster.VolumeMount{
-					{
-						Name:      kanikoSecretName,
-						MountPath: kanikoSecretMountpath,
-					},
-				},
-				Envs: []cluster.Env{
-					{
-						Name:  googleApplicationEnvVarName,
-						Value: kanikoSecretFilePath,
-					},
-				},
+				Args:         kanikoArgs,
+				VolumeMounts: volumeMounts,
+				Envs:         envVars,
 				Resources: cluster.RequestLimitResources{
 					Request: cluster.Resource{
 						CPU: resource.MustParse(
@@ -327,14 +344,10 @@ func (ib *imageBuilder) createKanikoJob(
 				},
 			},
 		},
-		SecretVolumes: []cluster.SecretVolume{
-			{
-				Name:       kanikoSecretName,
-				SecretName: kanikoSecretName,
-			},
-		},
+		SecretVolumes:  volumes,
 		TolerationName: ib.imageBuildingConfig.TolerationName,
 		NodeSelector:   ib.imageBuildingConfig.NodeSelector,
+		ServiceAccount: ib.imageBuildingConfig.KanikoConfig.ServiceAccount,
 	}
 
 	return ib.clusterController.CreateJob(

--- a/api/turing/imagebuilder/imagebuilder.go
+++ b/api/turing/imagebuilder/imagebuilder.go
@@ -259,7 +259,6 @@ func (ib *imageBuilder) createKanikoJob(
 		fmt.Sprintf("--dockerfile=%s", ib.imageBuildingConfig.KanikoConfig.DockerfileFilePath),
 		fmt.Sprintf("--context=%s", ib.imageBuildingConfig.KanikoConfig.BuildContextURI),
 		fmt.Sprintf("--build-arg=MODEL_URL=%s", artifactURI),
-		fmt.Sprintf("--build-arg=GOOGLE_APPLICATION_CREDENTIALS=%s", kanikoSecretFilePath),
 		fmt.Sprintf("--build-arg=BASE_IMAGE=%s", baseImage),
 		fmt.Sprintf("--build-arg=FOLDER_NAME=%s", folderName),
 		fmt.Sprintf("--destination=%s", imageRef),


### PR DESCRIPTION
## Context
Similar to how https://github.com/caraml-dev/merlin/pull/352 introduced a Kubernetes service account to be used for Kaniko jobs orchestrated by Merlin, this PR similarly introduces a similar change for Turing in its API server so that it is able to pass a configured Kaniko service account name to all the Kaniko jobs it orchestrates.

Note that not a lot of changes (if any) were made to the unit tests, despite the addition of a new service account (name) field, unlike in the Merlin repo. This is normal since Merlin is currently testing the image job creation workflows much more [extensively](https://github.com/caraml-dev/merlin/blob/da431b86a091b7966a65858f5961b432e8eeade6/api/pkg/imagebuilder/imagebuilder_test.go#L1294) in its unit tests, which isn't the case in Turing (we are only ascertaining that no error gets returned and the correct container image name gets returned). While it would be nice to introduce more extensive unit tests for Turing (so as to exhaustively test all the transformations performed in order to generate a K8s job manifest), this is out of scope of this PR and will probably be taken on at a later time.
