### PR TITLE
fix: Add check before activating service accounts in Kaniko build jobs

### DIFF
--- a/engines/pyfunc-ensembler-job/app.Dockerfile
+++ b/engines/pyfunc-ensembler-job/app.Dockerfile
@@ -4,7 +4,8 @@ FROM ${BASE_IMAGE}
 
 ARG MODEL_URL
 ARG GOOGLE_APPLICATION_CREDENTIALS
-RUN gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+# Run docker build using the credentials if provided
+RUN if [[-z "$GOOGLE_APPLICATION_CREDENTIALS"]]; then gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}; fi
 RUN gsutil -m cp -r ${MODEL_URL} .
 ARG FOLDER_NAME
 RUN /bin/bash -c ". activate ${CONDA_ENVIRONMENT} && conda env update --name ${CONDA_ENVIRONMENT} --file /${HOME}/${FOLDER_NAME}/conda.yaml"

--- a/engines/pyfunc-ensembler-service/app.Dockerfile
+++ b/engines/pyfunc-ensembler-service/app.Dockerfile
@@ -6,7 +6,8 @@ ARG MODEL_URL
 ARG FOLDER_NAME
 ARG GOOGLE_APPLICATION_CREDENTIALS
 
-RUN gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+# Run docker build using the credentials if provided
+RUN if [[-z "$GOOGLE_APPLICATION_CREDENTIALS"]]; then gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}; fi
 RUN gsutil -m cp -r ${MODEL_URL} .
 
 # Install dependencies required by the user-defined ensembler


### PR DESCRIPTION
## Context
With the changes in PR #357, there is a need to make additional changes to the Dockerfiles of the Kaniko image building templates - instead of authenticating immediately with `GOOGLE_APPLICATION_CREDENTIALS`, we now first check if that env var is defined, if so we will authenticate with the credentials stored in the file path pointed to by that env var; otherwise, the `gcloud auth activate-service-account` will not be run in the Dockerfile. In the second scenario, the Google service account credentials are expected to be passed to the Kaniko image building jobs via a mounted Kubernetes service account.

A similar change has been implemented in Merlin: https://github.com/caraml-dev/merlin/pull/352/files#diff-931d889c572814da3e253178b316471ac9878c45bf0497dd1792b5442eab359cR24