### PR TITLE
fix: Bump up caraml auth google

### DIFF
--- a/sdk/requirements.txt
+++ b/sdk/requirements.txt
@@ -11,4 +11,4 @@ protobuf>=3.0.0,<4.0.0dev
 python_dateutil>=2.5.3
 requests
 urllib3>=1.25.3
-caraml-auth-google==0.0.0.post6
+caraml-auth-google==0.0.0.post7


### PR DESCRIPTION
## Context
This PR is a fix to PR #343 which updated the `caraml-auth-google` package to use an older version of `urlllib3`. Previously, the `caraml-auth-google` package had an incorrect version of `urllib3` pinned; this PR thus updates the version of `caraml-auth-google` from `0.0.0.post6` to `0.0.0.post7`.