### PR TITLE
Use miniforge conda as Pyfunc ensembler service base image

### DIFF
--- a/engines/pyfunc-ensembler-job/Dockerfile
+++ b/engines/pyfunc-ensembler-job/Dockerfile
@@ -70,7 +70,7 @@ WORKDIR $HOME
 # Install miniconda
 ENV CONDA_DIR ${HOME}/miniconda3
 ENV PATH ${CONDA_DIR}/bin:$PATH
-ENV MINIFORGE_VERSION=4.14.0-0
+ENV MINIFORGE_VERSION=23.3.1-1
 
 RUN wget --quiet https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/Miniforge3-${MINIFORGE_VERSION}-Linux-x86_64.sh -O miniconda.sh && \
     /bin/bash miniconda.sh -b -p ${CONDA_DIR} && \

--- a/engines/pyfunc-ensembler-service/Dockerfile
+++ b/engines/pyfunc-ensembler-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/miniconda3 AS builder
+FROM condaforge/miniforge3:23.3.1-1 AS builder
 
 ARG APP_NAME
 ARG CONDA_ENV_NAME
@@ -17,4 +17,4 @@ RUN conda env create -f ./env-${PYTHON_VERSION}.yaml -n $CONDA_ENV_NAME &&  \
     rm -rf /root/.cache
 
 # Install conda-pack:
-RUN conda install -c conda-forge conda-pack
+RUN conda install conda-pack


### PR DESCRIPTION
Anaconda repo is no longer free for use, for companies with over 200 employees: https://community.anaconda.cloud/t/is-conda-cli-free-for-use/14303

This PR replaces `continuumio/miniconda3` used as the Pyfunc ensembler service base image with an image that uses [Miniforge](https://github.com/conda-forge/miniforge). With Miniforge:
> [conda-forge](https://conda-forge.org/) set as the default (and only) channel

![Screenshot 2023-09-08 at 8 04 47 AM](https://github.com/caraml-dev/turing/assets/23465343/873ab647-4995-4412-b38f-af68c7b3eb09)

![Screenshot 2023-09-08 at 8 05 04 AM](https://github.com/caraml-dev/turing/assets/23465343/99a635e5-5e66-4a93-939e-87350b2edfd5)

Additionally, the Miniforge conda version in the batch ensembler base image is updated to the latest as well.
