### PR TITLE
Remove multi-stage build from Pyfunc ensembler service

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ BatchEnsemblingConfig:
       BuildContextURI: git://github.com/caraml-dev/turing.git#refs/heads/main
       DockerfileFilePath: engines/pyfunc-ensembler-job/app.Dockerfile
       Image: gcr.io/kaniko-project/executor
-      ImageVersion: v1.6.0
+      ImageVersion: v1.15.0
       ResourceRequestsLimits:
         Requests:
           CPU: "1"

--- a/engines/pyfunc-ensembler-service/Dockerfile
+++ b/engines/pyfunc-ensembler-service/Dockerfile
@@ -15,6 +15,3 @@ COPY ./temp-deps/sdk ./../../sdk
 
 RUN conda env create -f ./env-${PYTHON_VERSION}.yaml -n $CONDA_ENV_NAME &&  \
     rm -rf /root/.cache
-
-# Install conda-pack:
-RUN conda install conda-pack

--- a/engines/pyfunc-ensembler-service/app.Dockerfile
+++ b/engines/pyfunc-ensembler-service/app.Dockerfile
@@ -12,6 +12,7 @@ RUN gsutil -m cp -r ${MODEL_URL} .
 
 RUN /bin/bash -c "conda env update --name ${CONDA_ENV_NAME} --file ./${FOLDER_NAME}/conda.yaml"
 
+ENV FOLDER_NAME=$FOLDER_NAME
 SHELL ["/bin/bash", "-c"]
 ENTRYPOINT . activate ${CONDA_ENV_NAME} && \
   python -m pyfunc_ensembler_runner --mlflow_ensembler_dir ./${FOLDER_NAME} -l INFO

--- a/engines/pyfunc-ensembler-service/app.Dockerfile
+++ b/engines/pyfunc-ensembler-service/app.Dockerfile
@@ -14,4 +14,4 @@ RUN /bin/bash -c "conda env update --name ${CONDA_ENV_NAME} --file ./${FOLDER_NA
 
 SHELL ["/bin/bash", "-c"]
 ENTRYPOINT . activate ${CONDA_ENV_NAME} && \
-  python -m /pyfunc_ensembler_runner --mlflow_ensembler_dir ./${FOLDER_NAME} -l INFO
+  python -m pyfunc_ensembler_runner --mlflow_ensembler_dir ./${FOLDER_NAME} -l INFO

--- a/engines/pyfunc-ensembler-service/app.Dockerfile
+++ b/engines/pyfunc-ensembler-service/app.Dockerfile
@@ -10,26 +10,8 @@ ARG GOOGLE_APPLICATION_CREDENTIALS
 RUN if [[-z "$GOOGLE_APPLICATION_CREDENTIALS"]]; then gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}; fi
 RUN gsutil -m cp -r ${MODEL_URL} .
 
-# Install dependencies required by the user-defined ensembler
-RUN conda env update --name ${CONDA_ENV_NAME} --file ./${FOLDER_NAME}/conda.yaml
-
-# Use conda-pack to create a standalone environment
-# in /venv:
-RUN conda-pack -n ${CONDA_ENV_NAME} -o /tmp/env.tar && \
-  mkdir /venv && cd /venv && tar xf /tmp/env.tar && \
-  rm /tmp/env.tar
-
-RUN /venv/bin/conda-unpack
-
-FROM debian:bullseye-slim
-
-ARG FOLDER_NAME
-ENV FOLDER_NAME=$FOLDER_NAME
-
-COPY --from=builder /${FOLDER_NAME} ./${FOLDER_NAME}
-COPY --from=builder /pyfunc_ensembler_runner ./pyfunc_ensembler_runner
-COPY --from=builder /venv ./venv
+RUN /bin/bash -c ". activate ${CONDA_ENV_NAME} && \
+  conda env update --name ${CONDA_ENV_NAME} --file ./${FOLDER_NAME}/conda.yaml"
 
 SHELL ["/bin/bash", "-c"]
-ENTRYPOINT source /venv/bin/activate && \
-  python -m pyfunc_ensembler_runner --mlflow_ensembler_dir /${FOLDER_NAME} -l INFO
+ENTRYPOINT python -m pyfunc_ensembler_runner --mlflow_ensembler_dir ./${FOLDER_NAME} -l INFO

--- a/engines/pyfunc-ensembler-service/app.Dockerfile
+++ b/engines/pyfunc-ensembler-service/app.Dockerfile
@@ -10,8 +10,8 @@ ARG GOOGLE_APPLICATION_CREDENTIALS
 RUN if [[-z "$GOOGLE_APPLICATION_CREDENTIALS"]]; then gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}; fi
 RUN gsutil -m cp -r ${MODEL_URL} .
 
-RUN /bin/bash -c ". activate ${CONDA_ENV_NAME} && \
-  conda env update --name ${CONDA_ENV_NAME} --file ./${FOLDER_NAME}/conda.yaml"
+RUN /bin/bash -c "conda env update --name ${CONDA_ENV_NAME} --file ./${FOLDER_NAME}/conda.yaml"
 
 SHELL ["/bin/bash", "-c"]
-ENTRYPOINT python -m pyfunc_ensembler_runner --mlflow_ensembler_dir ./${FOLDER_NAME} -l INFO
+ENTRYPOINT . activate ${CONDA_ENV_NAME} && \
+  python -m /pyfunc_ensembler_runner --mlflow_ensembler_dir ./${FOLDER_NAME} -l INFO

--- a/infra/charts/turing/values.yaml
+++ b/infra/charts/turing/values.yaml
@@ -149,7 +149,7 @@ turing:
           BuildContextURI: git://github.com/caraml-dev/turing.git#refs/heads/main
           DockerfileFilePath: engines/pyfunc-ensembler-service/app.Dockerfile
           Image: gcr.io/kaniko-project/executor
-          ImageVersion: v1.6.0
+          ImageVersion: v1.15.0
           ResourceRequestsLimits:
             Requests:
               CPU: "1"


### PR DESCRIPTION
This PR upgrades the Kaniko image version used in the Turing infra chart.

With this Kaniko version, the Pyfunc ensembler service image builds require a lot more memory and often get OOMKilled (based on internal tests). Thus, to get around this, the multi-stage build is removed from the `Dockerfile` (which is the same approach as Merlin's Pyfunc models - [ref](https://github.com/caraml-dev/merlin/blob/v0.33.0/python/pyfunc-server/docker/Dockerfile)) to save build time and resources.

However, removing the multi-stage build does result in a larger built image size (about 500MB larger). Optimizing the image building process will be taken up separately.
