### PR TITLE
fix: Change delete ensembler api response from int to struct

### DIFF
--- a/api/turing/api/ensemblers_api.go
+++ b/api/turing/api/ensemblers_api.go
@@ -213,7 +213,7 @@ func (c EnsemblersController) DeleteEnsembler(
 		return Error(httpStatus, "failed to delete the ensembler", err.Error())
 	}
 
-	return Ok(ensembler.GetID())
+	return Ok(map[string]int{"id": int(ensembler.GetID())})
 }
 
 func (c EnsemblersController) checkActiveRouterVersion(options EnsemblersPathOptions) (int, error) {

--- a/api/turing/api/ensemblers_api_test.go
+++ b/api/turing/api/ensemblers_api_test.go
@@ -917,7 +917,7 @@ func TestEnsemblerController_DeleteEnsembler(t *testing.T) {
 				mlflowSvc.On("DeleteExperiment", mock.Anything, "1", true).Return(nil)
 				return mlflowSvc
 			},
-			expected: Ok(models.ID(2)),
+			expected: Ok(map[string]int{"id": 2}),
 		},
 		"success": {
 			vars: RequestVars{
@@ -962,7 +962,7 @@ func TestEnsemblerController_DeleteEnsembler(t *testing.T) {
 				mlflowSvc.On("DeleteExperiment", mock.Anything, "1", true).Return(nil)
 				return mlflowSvc
 			},
-			expected: Ok(models.ID(2)),
+			expected: Ok(map[string]int{"id": 2}),
 		},
 	}
 	for name, tt := range tests {


### PR DESCRIPTION
## Context
The delete ensembler API endpoint currently returns an `int` (representing the id of the deleted ensembler) as part of a 200 response if the deletion occurs successfully. This is inconsistent with the specification in the Turing API server's OpenAPI specs which specifies a struct with the schema `{"id": [ensembler id]}` (this itself is consistent with the delete router API endpoint responses). See https://github.com/caraml-dev/turing/blob/main/api/api/specs/ensemblers.yaml#L147 and https://github.com/caraml-dev/turing/blob/main/api/api/specs/common.yaml#L14 for the exact schema definitions.

As such, using the Turing SDK to delete ensemblers would throw errors as the autogenerated OpenAPI classes would expect a struct in the response body instead of an `int`. This PR thus fixes the response returned by the API server when this endpoint is used.