### PR TITLE
Remove support for Python 3.7

### DIFF
--- a/.github/workflows/pyfunc-ensembler-job.yaml
+++ b/.github/workflows/pyfunc-ensembler-job.yaml
@@ -30,8 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # TODO: Remove support for Python 3.7
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
     
     steps:
       - uses: actions/checkout@v3
@@ -93,8 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # TODO: Remove support for Python 3.7
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
     needs:
       - release-rules
       - test

--- a/.github/workflows/pyfunc-ensembler-service.yaml
+++ b/.github/workflows/pyfunc-ensembler-service.yaml
@@ -30,8 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # TODO: Remove support for Python 3.7
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v3
@@ -87,8 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # TODO: Remove support for Python 3.7
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
     needs:
       - release-rules
       - test

--- a/engines/pyfunc-ensembler-job/Dockerfile
+++ b/engines/pyfunc-ensembler-job/Dockerfile
@@ -1,6 +1,4 @@
-ARG SPARK_VERSION=v3.0.0
-
-FROM gcr.io/spark-operator/spark-py:$SPARK_VERSION
+FROM apache/spark-py:v3.1.3
 
 ENV SPARK_OPERATOR_VERSION=v1beta2-1.3.7-3.1.1
 ENV SPARK_BQ_CONNECTOR_VERSION=0.27.0

--- a/engines/pyfunc-ensembler-job/env-3.7.yaml
+++ b/engines/pyfunc-ensembler-job/env-3.7.yaml
@@ -1,8 +1,0 @@
-name: pyfunc-ensembler-job
-dependencies:
-  - python=3.7.*
-  - pip=22.2.2
-  - pip:
-      - -r requirements.txt
-      - --extra-index-url=https://test.pypi.org/simple
-      - --trusted-host=test.pypi.org

--- a/engines/pyfunc-ensembler-job/requirements.txt
+++ b/engines/pyfunc-ensembler-job/requirements.txt
@@ -9,5 +9,4 @@ py4j==0.10.9
 pyarrow>=0.14.1,<=9.0.0
 pyspark==3.0.1
 pyyaml==6.0
-#TODO: Update turing-sdk dep to: file:../../sdk
-turing-sdk==0.11.0 # Pin to the version that supports Python 3.7.
+file:../../sdk

--- a/engines/pyfunc-ensembler-job/setup.py
+++ b/engines/pyfunc-ensembler-job/setup.py
@@ -20,5 +20,5 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=requirements,
     dev_requirements=dev_requirements,
-    python_requires=">=3.7,<3.11",
+    python_requires=">=3.8,<3.11",
 )

--- a/engines/pyfunc-ensembler-service/env-3.7.yaml
+++ b/engines/pyfunc-ensembler-service/env-3.7.yaml
@@ -1,8 +1,0 @@
-name: pyfunc-ensembler-service
-dependencies:
-  - python=3.7.*
-  - pip=21.2.2
-  - pip:
-      - -r requirements.txt
-      - --extra-index-url=https://test.pypi.org/simple
-      - --trusted-host=test.pypi.org

--- a/engines/pyfunc-ensembler-service/requirements.txt
+++ b/engines/pyfunc-ensembler-service/requirements.txt
@@ -2,5 +2,4 @@ argparse>=1.4.0
 cloudpickle==2.0.0
 orjson==3.6.8
 tornado==6.1
-#TODO: Update turing-sdk dep to: file:../../sdk
-turing-sdk==0.11.0 # Pin to the version that supports Python 3.7.
+file:../../sdk

--- a/engines/pyfunc-ensembler-service/setup.py
+++ b/engines/pyfunc-ensembler-service/setup.py
@@ -20,5 +20,5 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=requirements,
     dev_requirements=dev_requirements,
-    python_requires=">=3.7,<3.11",
+    python_requires=">=3.8,<3.11",
 )

--- a/sdk/samples/quickstart/quick_start.py
+++ b/sdk/samples/quickstart/quick_start.py
@@ -37,7 +37,7 @@ def main(turing_api: str, project: str):
         ensembler_instance=MyEnsembler(),
         conda_env={
             "channels": ["defaults"],
-            "dependencies": ["python=3.7.0", "cookiecutter>=1.7.2", "numpy"],
+            "dependencies": ["python=3.9.0", "cookiecutter>=1.7.2", "numpy"],
         },
         code_dir=[os.path.join(os.path.dirname(__file__), "../../samples")],
     )

--- a/sdk/tests/ensembler_test.py
+++ b/sdk/tests/ensembler_test.py
@@ -106,7 +106,7 @@ def test_create_ensembler(
         ensembler_instance=tests.MyTestEnsembler(0.01),
         conda_env={
             "channels": ["defaults"],
-            "dependencies": ["python=3.7.0", {"pip": ["test-lib==0.0.1"]}],
+            "dependencies": ["python=3.9.0", {"pip": ["test-lib==0.0.1"]}],
         },
     )
 


### PR DESCRIPTION
This MR is the continuation of https://github.com/caraml-dev/turing/pull/362 and drops Python 3.7 support also from the Pyfunc servers for real-time and batch ensemblers.

Docs and examples are also updated to replace Python 3.7 with a higher version.

In addition, the base image for the batch ensembler job is updated to `apache/spark-py:v3.1.3` as the Google spark operator image has been recalled due to vulnerabilities. Ref: https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/1862