### PR TITLE
Upgrade MLflow client

### DIFF
--- a/docs/how-to/create-a-router/configure-ensembler.md
+++ b/docs/how-to/create-a-router/configure-ensembler.md
@@ -104,7 +104,11 @@ Similar to requests sent to a Docker Ensembler, the request payload sent to a Py
 original request, responses from all routes, and the treatment configuration (if an Experiment
 Engine is selected, in the Configure Experiment Engine step). The ensembler's request headers will contain the original
 request headers sent to Turing, merged with the enricher's response headers (if there are duplicates, the value in
-the enricher's response headers will take precedence), and an identifier `Turing-Req-Id` that is uniquely assigned to each request received by the Router. 
+the enricher's response headers will take precedence), and an identifier `Turing-Req-Id` that is uniquely assigned to each request received by the Router.
+
+**Note on compatibility**: The Pyfunc servers are compatible with `protobuf>=3.12.0,<5.0.0`. Users whose ensemblers have a strong dependency on Protobuf `3.x.x` are advised to pin the library version in their conda environment, when submitting the ensembler. If using Protobuf `3.x.x` with the UPI protocol, users can do one of the following:
+* Use `protobuf>=3.20.0` - these versions support simplified class definitions and this is the recommended approach.
+* If you must use `protobuf>=3.12.0,<3.20.0`, please pin `caraml-upi-protos<=0.3.6` in your ensembler’s conda environment.
 
 To configure your router with a Pyfunc ensembler, simply select from the drop down list your desired ensembler, 
 registered in your current project. You'll also need to indicate your desired timeout value and resource request values:

--- a/engines/pyfunc-ensembler-job/requirements.txt
+++ b/engines/pyfunc-ensembler-job/requirements.txt
@@ -2,7 +2,6 @@ cloudpickle==2.0.0
 google-cloud-storage>=1.37.0
 jinjasql==0.1.8
 jinja2==3.0.3
-mlflow>=1.2.0,<=1.23.0
 numpy==1.21.6
 pandas==1.3.5
 py4j==0.10.9

--- a/sdk/requirements.dev.txt
+++ b/sdk/requirements.dev.txt
@@ -6,6 +6,4 @@ pytest
 pytest-cov
 urllib3-mock>=0.3.3
 caraml-upi-protos
-grpcio<1.49.0
-grpcio-reflection<1.49.0
-grpcio-tools<1.49.0
+grpcio-reflection

--- a/sdk/requirements.txt
+++ b/sdk/requirements.txt
@@ -2,12 +2,12 @@ cloudpickle==2.0.0
 deprecation==2.1.0
 fire
 google-cloud-storage>=1.19.0
-mlflow>=1.2.0,<=1.23.0
+mlflow>=1.26.1,<2.0.0
 # Numpy >= v1.24.0 is incompatible with our pinned versions of mlflow due to the deprecation of several common numpy
 # aliases (see the last bullet point here: https://numpy.org/doc/stable/release/1.24.0-notes.html#expired-deprecations).
 numpy<1.24.0
 pandas
-protobuf>=3.0.0,<4.0.0dev
+protobuf>=3.12.0,<5.0.0 # Determined by the mlflow dependency
 python_dateutil>=2.5.3
 requests
 urllib3>=1.25.3


### PR DESCRIPTION
This PR upgrades the `mlflow` client dependency on the SDK (and therefore the Pyfunc servers) to `mlflow>=1.26.1,<2.0.0`. Accordingly, the `protobuf` dependency range is updated as well.

Related MRs in Merlin:
* https://github.com/caraml-dev/merlin/pull/465
* https://github.com/caraml-dev/merlin/pull/485
* https://github.com/caraml-dev/merlin/pull/486
* https://github.com/caraml-dev/merlin/pull/487