### PR TITLE
fix(image-builder):Refactor ensembler image naming convention

### DIFF
--- a/api/turing/imagebuilder/ensembler.go
+++ b/api/turing/imagebuilder/ensembler.go
@@ -39,11 +39,8 @@ func (n *ensemblerJobNameGenerator) generateBuilderName(
 }
 
 // generateDockerImageName generate the name of docker image of prediction job that will be created from given model
-func (n *ensemblerJobNameGenerator) generateDockerImageName(projectName string,
-	modelName string,
-	runID string,
-) string {
-	return fmt.Sprintf("%s/%s-%s-%s-job", n.registry, projectName, modelName, runID)
+func (n *ensemblerJobNameGenerator) generateDockerImageName(projectName string, modelName string) string {
+	return fmt.Sprintf("%s/%s/ensembler-jobs/%s", n.registry, projectName, modelName)
 }
 
 // NewEnsemblerServiceImageBuilder create ImageBuilder for building docker image of the ensembling service (real-time)
@@ -78,12 +75,8 @@ func (n *ensemblerServiceNameGenerator) generateBuilderName(
 
 // generateServiceImageName generate the name of docker image of the ensembling service that will be created from given
 // model
-func (n *ensemblerServiceNameGenerator) generateDockerImageName(
-	projectName string,
-	modelName string,
-	runID string,
-) string {
-	return fmt.Sprintf("%s/%s-%s-%s-service", n.registry, projectName, modelName, runID)
+func (n *ensemblerServiceNameGenerator) generateDockerImageName(projectName string, modelName string) string {
+	return fmt.Sprintf("%s/%s/ensembler-services/%s", n.registry, projectName, modelName)
 }
 
 func getPartialVersionID(versionID string, numChar int) string {

--- a/api/turing/imagebuilder/imagebuilder.go
+++ b/api/turing/imagebuilder/imagebuilder.go
@@ -92,7 +92,7 @@ type nameGenerator interface {
 	// generateBuilderJobName generate kaniko job name that will be used to build a docker image
 	generateBuilderName(projectName string, modelName string, modelID models.ID, versionID string) string
 	// generateDockerImageName generate image name based on project and model
-	generateDockerImageName(projectName string, modelName string, versionID string) string
+	generateDockerImageName(projectName string, modelName string) string
 }
 
 type imageBuilder struct {
@@ -120,9 +120,9 @@ func newImageBuilder(
 }
 
 func (ib *imageBuilder) BuildImage(request BuildImageRequest) (string, error) {
-	imageName := ib.nameGenerator.generateDockerImageName(request.ProjectName, request.ResourceName, request.VersionID)
+	imageName := ib.nameGenerator.generateDockerImageName(request.ProjectName, request.ResourceName)
 	imageExists, err := ib.checkIfImageExists(imageName, strconv.Itoa(int(request.ResourceID)))
-	imageRef := fmt.Sprintf("%s:%d", imageName, request.ResourceID)
+	imageRef := fmt.Sprintf("%s:%s", imageName, request.VersionID)
 	if err != nil {
 		log.Errorf("Unable to check existing image ref: %v", err)
 		return "", ErrUnableToGetImageRef

--- a/api/turing/imagebuilder/imagebuilder_test.go
+++ b/api/turing/imagebuilder/imagebuilder_test.go
@@ -80,7 +80,7 @@ func TestBuildPyFuncEnsemblerJobImage(t *testing.T) {
 		imageTag            string
 	}{
 		"success | no existing job": {
-			expected:    fmt.Sprintf("%s/%s-%s-%s-job:%d", dockerRegistry, projectName, modelName, runID, modelVersion),
+			expected:    fmt.Sprintf("%s/%s/ensembler-jobs/%s:%s", dockerRegistry, projectName, modelName, runID),
 			projectName: projectName,
 			modelName:   modelName,
 			modelID:     modelVersion,
@@ -141,7 +141,7 @@ func TestBuildPyFuncEnsemblerJobImage(t *testing.T) {
 			imageTag:            "3.7.*",
 		},
 		"success: existing job is running": {
-			expected:    fmt.Sprintf("%s/%s-%s-%s-job:%d", dockerRegistry, projectName, modelName, runID, modelVersion),
+			expected:    fmt.Sprintf("%s/%s/ensembler-jobs/%s:%s", dockerRegistry, projectName, modelName, runID),
 			projectName: projectName,
 			modelName:   modelName,
 			modelID:     modelVersion,
@@ -203,7 +203,7 @@ func TestBuildPyFuncEnsemblerJobImage(t *testing.T) {
 			imageTag:            "3.7.*",
 		},
 		"success: existing job failed": {
-			expected:    fmt.Sprintf("%s/%s-%s-%s-job:%d", dockerRegistry, projectName, modelName, runID, modelVersion),
+			expected:    fmt.Sprintf("%s/%s/ensembler-jobs/%s:%s", dockerRegistry, projectName, modelName, runID),
 			projectName: projectName,
 			modelName:   modelName,
 			modelID:     modelVersion,
@@ -357,7 +357,7 @@ func TestBuildPyFuncEnsemblerServiceImage(t *testing.T) {
 		imageTag                   string
 	}{
 		"success | no existing job": {
-			expectedImage: fmt.Sprintf("%s/%s-%s-%s-service:%d", dockerRegistry, projectName, modelName, runID, modelVersion),
+			expectedImage: fmt.Sprintf("%s/%s/ensembler-services/%s:%s", dockerRegistry, projectName, modelName, runID),
 			projectName:   projectName,
 			modelName:     modelName,
 			modelID:       modelVersion,
@@ -418,7 +418,7 @@ func TestBuildPyFuncEnsemblerServiceImage(t *testing.T) {
 			imageTag:            "3.7.*",
 		},
 		"success: existing job is running": {
-			expectedImage: fmt.Sprintf("%s/%s-%s-%s-service:%d", dockerRegistry, projectName, modelName, runID, modelVersion),
+			expectedImage: fmt.Sprintf("%s/%s/ensembler-services/%s:%s", dockerRegistry, projectName, modelName, runID),
 			projectName:   projectName,
 			modelName:     modelName,
 			modelID:       modelVersion,
@@ -480,7 +480,7 @@ func TestBuildPyFuncEnsemblerServiceImage(t *testing.T) {
 			imageTag:            "3.7.*",
 		},
 		"success: existing job failed": {
-			expectedImage: fmt.Sprintf("%s/%s-%s-%s-service:%d", dockerRegistry, projectName, modelName, runID, modelVersion),
+			expectedImage: fmt.Sprintf("%s/%s/ensembler-services/%s:%s", dockerRegistry, projectName, modelName, runID),
 			projectName:   projectName,
 			modelName:     modelName,
 			modelID:       modelVersion,


### PR DESCRIPTION
## Context
This fix/enhancement revises the image naming convention for both ensembler service and ensembler job images built by the image builder:

### Before
```
{dockerRegistry}/{projectName}-{ensemblerName}-{runID}-service:{ensemblerID}
```
or
```
{dockerRegistry}/{projectName}-{ensemblerName}-{runID}-job:{ensemblerID}
```

### After
```
{dockerRegistry}/{projectName}/ensembler-services/{ensemblerName}:{runID}
```
or 
```
{dockerRegistry}/{projectName}/ensembler-jobs/{ensemblerName}:{runID}
```

By removing the `runID` from the image name, we now allow all images built for the same ensembler to be stored within the same image repository as opposed to storing them in separate repositories. Furthermore, since all built images of the same ensembler will now be stored in the same repository, we now tag them with their specific `runID`-s in order to distinguish between different versions of the same ensembler.

**_This PR contains changes similar to what is implemented for Merlin in https://github.com/caraml-dev/merlin/pull/526._** 

## Modifications
- `api/turing/imagebuilder/ensembler.go` - Change in template string for the ensembler image name
- `api/turing/imagebuilder/imagebuilder.go` - Change of image tag from `ensemblerID` to `runID`