### PR TITLE
feat(ui): Remove ticks and display min-max labels in EuiDualRange slider

### DIFF
--- a/ui/src/router/components/form/components/ResourcesPanel.js
+++ b/ui/src/router/components/form/components/ResourcesPanel.js
@@ -12,8 +12,6 @@ import {
 import { FormLabelWithToolTip } from "../../../../components/form/label_with_tooltip/FormLabelWithToolTip";
 import { useOnChangeHandler } from "../../../../components/form/hooks/useOnChangeHandler";
 
-const maxTicks = 20;
-
 export const ResourcesPanel = ({
   resourcesConfig,
   onChangeHandler,
@@ -90,10 +88,8 @@ export const ResourcesPanel = ({
             fullWidth
             min={0}
             max={maxAllowedReplica}
-            // This component only allows up to 20 ticks to be displayed at the slider
-            tickInterval={Math.ceil((maxAllowedReplica + 1) / maxTicks)}
             showInput
-            showTicks
+            showLabels
             value={[
               resourcesConfig.min_replica || 0,
               resourcesConfig.max_replica || 0,


### PR DESCRIPTION
## Context
Similar to https://github.com/caraml-dev/merlin/pull/546 whereby the min-max replica slider bar has been slightly modified by removing the ticks to better accommodate larger ranges (e.g. 100 replicas), this PR makes similar changes to the Turing UI in order to keep the design of the resource request components similar in both Turing and Merlin.

### New design of the resource requests component
![Screenshot 2024-03-04 at 2 13 24 PM](https://github.com/caraml-dev/turing/assets/36802364/566cb67e-c6b5-4808-8710-2692252de6c7)
Notice how the min and max values are now displayed as labels at the ends of the slider bar.

## Changes 
- `ui/src/router/components/form/components/ResourcesPanel.js` - Removal of ticks and addition of min-max labels