### PR TITLE
fix(api): Fix incorrect tag name used to check for the existence of built docker images

### DIFF
--- a/api/turing/imagebuilder/imagebuilder.go
+++ b/api/turing/imagebuilder/imagebuilder.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -122,7 +121,7 @@ func newImageBuilder(
 
 func (ib *imageBuilder) BuildImage(request BuildImageRequest) (string, error) {
 	imageName := ib.nameGenerator.generateDockerImageName(request.ProjectName, request.ResourceName)
-	imageExists, err := ib.checkIfImageExists(imageName, strconv.Itoa(int(request.ResourceID)))
+	imageExists, err := ib.checkIfImageExists(imageName, request.VersionID)
 	imageRef := fmt.Sprintf("%s:%s", imageName, request.VersionID)
 	if err != nil {
 		log.Errorf("Unable to check existing image ref: %v", err)


### PR DESCRIPTION
## Context
Following up on the changes to edit the naming convention of docker images built by the Turing API server in PR #368, this PR introduces a tiny fix to a part of the image building process that checks for the existence of a docker image with the same tag.

Previously the tag was left as the ensembler id, which is incorrectly, given the changes proposed in PR #368. This PR corrects the image tag used for the check mentioned above to the ensembler run id. Here's a recap of how the changes should look like:

### Before
```
{dockerRegistry}/{projectName}-{ensemblerName}-{runID}-service:{ensemblerID}
```
or
```
{dockerRegistry}/{projectName}-{ensemblerName}-{runID}-job:{ensemblerID}
```

### After
```
{dockerRegistry}/{projectName}/ensembler-services/{ensemblerName}:{runID}
```
or 
```
{dockerRegistry}/{projectName}/ensembler-jobs/{ensemblerName}:{runID}
```