### PR TITLE
feat: support array in experiment engine json

### DIFF
--- a/engines/experiment/pkg/request/request.go
+++ b/engines/experiment/pkg/request/request.go
@@ -115,7 +115,7 @@ func getValueFromJSONPayload(body []byte, key string) (string, error) {
 	value, typez, _, _ := jsonparser.Get(body, strings.Split(key, ".")...)
 
 	switch typez {
-	case jsonparser.String, jsonparser.Number, jsonparser.Boolean, jsonparser.Array:
+	case jsonparser.String, jsonparser.Number, jsonparser.Boolean, jsonparser.Array, jsonparser.Object:
 		// See: https://github.com/buger/jsonparser/blob/master/bytes_unsafe.go#L31
 		return *(*string)(unsafe.Pointer(&value)), nil
 	case jsonparser.Null:

--- a/engines/experiment/pkg/request/request.go
+++ b/engines/experiment/pkg/request/request.go
@@ -60,7 +60,7 @@ func GetValueFromHTTPRequest(
 	case PayloadFieldSource:
 		return getValueFromJSONPayload(bodyBytes, field)
 	case HeaderFieldSource:
-		value := reqHeader.Get(field)
+		value := strings.Join(reqHeader.Values(field), ",")
 		if value == "" {
 			// key not found in header
 			return "", fmt.Errorf("Field %s not found in the request header", field)
@@ -115,7 +115,7 @@ func getValueFromJSONPayload(body []byte, key string) (string, error) {
 	value, typez, _, _ := jsonparser.Get(body, strings.Split(key, ".")...)
 
 	switch typez {
-	case jsonparser.String, jsonparser.Number, jsonparser.Boolean:
+	case jsonparser.String, jsonparser.Number, jsonparser.Boolean, jsonparser.Array:
 		// See: https://github.com/buger/jsonparser/blob/master/bytes_unsafe.go#L31
 		return *(*string)(unsafe.Pointer(&value)), nil
 	case jsonparser.Null:

--- a/engines/experiment/pkg/request/request.go
+++ b/engines/experiment/pkg/request/request.go
@@ -120,9 +120,10 @@ func getValueFromJSONPayload(body []byte, key string) (string, error) {
 		return *(*string)(unsafe.Pointer(&value)), nil
 	case jsonparser.Null:
 		return "", nil
-	// Default non exist
-	default:
+	case jsonparser.NotExist:
 		return "", errors.Errorf("Field %s not found in the request payload: Key path not found", key)
+	default:
+		return "", errors.Errorf("Field %s can not be parsed as string value, unsupported type: %s", key, dataType.String())
 	}
 }
 

--- a/engines/experiment/pkg/request/request.go
+++ b/engines/experiment/pkg/request/request.go
@@ -112,19 +112,17 @@ func GetValueFromUPIRequest(
 
 func getValueFromJSONPayload(body []byte, key string) (string, error) {
 	// Retrieve value using JSON path
-	value, typez, _, _ := jsonparser.Get(body, strings.Split(key, ".")...)
+	value, dataType, _, _ := jsonparser.Get(body, strings.Split(key, ".")...)
 
-	switch typez {
+	switch dataType {
 	case jsonparser.String, jsonparser.Number, jsonparser.Boolean, jsonparser.Array, jsonparser.Object:
 		// See: https://github.com/buger/jsonparser/blob/master/bytes_unsafe.go#L31
 		return *(*string)(unsafe.Pointer(&value)), nil
 	case jsonparser.Null:
 		return "", nil
-	case jsonparser.NotExist:
-		return "", errors.Errorf("Field %s not found in the request payload: Key path not found", key)
+	// Default non exist
 	default:
-		return "", errors.Errorf(
-			"Field %s can not be parsed as string value, unsupported type: %s", key, typez.String())
+		return "", errors.Errorf("Field %s not found in the request payload: Key path not found", key)
 	}
 }
 

--- a/engines/experiment/pkg/request/request_test.go
+++ b/engines/experiment/pkg/request/request_test.go
@@ -62,6 +62,18 @@ func TestGetValueFromHTTPRequest(t *testing.T) {
 			body:     []byte(`{"is_premium_customer": true}`),
 			expected: "true",
 		},
+		"success | array string": {
+			field:    "customers",
+			fieldSrc: request.PayloadFieldSource,
+			body:     []byte(`{"customers": ["123","321"]}`),
+			expected: `["123","321"]`,
+		},
+		"success | array int": {
+			field:    "customers",
+			fieldSrc: request.PayloadFieldSource,
+			body:     []byte(`{"customers": [123,321]}`),
+			expected: `[123,321]`,
+		},
 		"success | payload null field": {
 			field:    "session_id",
 			fieldSrc: request.PayloadFieldSource,

--- a/engines/experiment/pkg/request/request_test.go
+++ b/engines/experiment/pkg/request/request_test.go
@@ -44,6 +44,17 @@ func TestGetValueFromHTTPRequest(t *testing.T) {
 			}(),
 			expected: "123",
 		},
+		"success | header multiple value": {
+			field:    "CustomerID",
+			fieldSrc: request.HeaderFieldSource,
+			header: func() http.Header {
+				header := http.Header{}
+				header.Set("CustomerID", "123")
+				header.Add("CustomerID", "321")
+				return header
+			}(),
+			expected: "123,321",
+		},
 		"success | nested payload": {
 			field:    "customer.id",
 			fieldSrc: request.PayloadFieldSource,

--- a/engines/experiment/pkg/request/request_test.go
+++ b/engines/experiment/pkg/request/request_test.go
@@ -96,6 +96,12 @@ func TestGetValueFromHTTPRequest(t *testing.T) {
 			body:     []byte(`{"customer": {"id": "test_customer"}}`),
 			err:      "Field customer_id not found in the request payload: Key path not found",
 		},
+		"failure | payload unsupported type": {
+			field:    "customer",
+			fieldSrc: request.PayloadFieldSource,
+			body:     []byte(`{"customer": !!!`),
+			err:      "Field customer can not be parsed as string value, unsupported type: unknown",
+		},
 		"failure | unknown source": {
 			field:    "CustomerID",
 			fieldSrc: request.FieldSource("unknown"),

--- a/engines/experiment/pkg/request/request_test.go
+++ b/engines/experiment/pkg/request/request_test.go
@@ -85,6 +85,12 @@ func TestGetValueFromHTTPRequest(t *testing.T) {
 			body:     []byte(`{"customers": [123,321]}`),
 			expected: `[123,321]`,
 		},
+		"success | object": {
+			field:    "customers",
+			fieldSrc: request.PayloadFieldSource,
+			body:     []byte(`{"customers": {"a":"b"}}`),
+			expected: `{"a":"b"}`,
+		},
 		"success | payload null field": {
 			field:    "session_id",
 			fieldSrc: request.PayloadFieldSource,

--- a/engines/experiment/pkg/request/request_test.go
+++ b/engines/experiment/pkg/request/request_test.go
@@ -96,12 +96,6 @@ func TestGetValueFromHTTPRequest(t *testing.T) {
 			body:     []byte(`{"customer": {"id": "test_customer"}}`),
 			err:      "Field customer_id not found in the request payload: Key path not found",
 		},
-		"failure | payload unsupported type": {
-			field:    "customer",
-			fieldSrc: request.PayloadFieldSource,
-			body:     []byte(`{"customer": {"id": 42, "email": "test@test.com"}`),
-			err:      "Field customer can not be parsed as string value, unsupported type: object",
-		},
 		"failure | unknown source": {
 			field:    "CustomerID",
 			fieldSrc: request.FieldSource("unknown"),


### PR DESCRIPTION
# Description

Update to the `engines/experiment/pkg/request/request.go` to support object and array type.

The underlying method does support object and array by presumingly older requirements then, these type are not supported. However due to evolving experiment segments that involves array and dictionary, these would required to be updated

![image](https://github.com/caraml-dev/turing/assets/30390872/c4c79061-25b6-4a0e-b463-cbfeea6f221e)
