### PR TITLE
fix(sdk): Remove exp engine passkey when retrieving routers from the API server

### DIFF
--- a/engines/pyfunc-ensembler-service/requirements.dev.txt
+++ b/engines/pyfunc-ensembler-service/requirements.dev.txt
@@ -1,4 +1,5 @@
 black==22.6.0
-pytest
+# The next release 8.2.0 of pytest breaks the unit tests
+pytest<=8.1.2
 pytest-cov
 pylint

--- a/sdk/requirements.dev.txt
+++ b/sdk/requirements.dev.txt
@@ -2,7 +2,8 @@ black==22.6.0
 setuptools>=21.0.0
 wheel
 twine
-pytest
+# The next release 8.0.0 of pytest breaks the unit tests
+pytest<=7.4.4
 pytest-cov
 urllib3-mock>=0.3.3
 caraml-upi-protos

--- a/sdk/tests/router/config/router_version_test.py
+++ b/sdk/tests/router/config/router_version_test.py
@@ -52,8 +52,9 @@ def test_create_version(
 
     # Assert the response against an experiment engine object that has its passkey removed
     expected_experiment_engine = generic_router_version.experiment_engine
-    if expected_experiment_engine.config.get("client") is not None \
-            and expected_experiment_engine.config["client"].get("passkey") != "":
+    if expected_experiment_engine.config is not None and \
+            expected_experiment_engine.config.get("client") is not None and \
+            expected_experiment_engine.config["client"].get("passkey") != "":
         expected_experiment_engine.config["client"]["passkey"] = None
     assert (
         actual_response.experiment_engine.to_open_api()

--- a/sdk/tests/router/config/router_version_test.py
+++ b/sdk/tests/router/config/router_version_test.py
@@ -49,9 +49,15 @@ def test_create_version(
         assert actual_response.rules[i].to_open_api() == generic_router_version.rules[i]
 
     assert actual_response.default_route_id == generic_router_version.default_route_id
+
+    # Assert the response against an experiment engine object that has its passkey removed
+    expected_experiment_engine = generic_router_version.experiment_engine
+    if expected_experiment_engine.config.get("client") is not None \
+            and expected_experiment_engine.config["client"].get("passkey") != "":
+        expected_experiment_engine.config["client"]["passkey"] = None
     assert (
         actual_response.experiment_engine.to_open_api()
-        == generic_router_version.experiment_engine
+        == expected_experiment_engine
     )
     assert (
         actual_response.resource_request.to_open_api()

--- a/sdk/turing/router/config/router_config.py
+++ b/sdk/turing/router/config/router_config.py
@@ -211,6 +211,9 @@ class RouterConfig:
             self._experiment_engine = experiment_engine
         elif isinstance(experiment_engine, dict):
             self._experiment_engine = ExperimentConfig(**experiment_engine)
+            if self._experiment_engine.config.get("client") is not None \
+                    and self._experiment_engine.config["client"].get("passkey") != "":
+                self._experiment_engine.config["client"]["passkey"] = None
         else:
             self._experiment_engine = experiment_engine
 

--- a/sdk/turing/router/config/router_config.py
+++ b/sdk/turing/router/config/router_config.py
@@ -211,8 +211,9 @@ class RouterConfig:
             self._experiment_engine = experiment_engine
         elif isinstance(experiment_engine, dict):
             self._experiment_engine = ExperimentConfig(**experiment_engine)
-            if self._experiment_engine.config.get("client") is not None \
-                    and self._experiment_engine.config["client"].get("passkey") != "":
+            if self._experiment_engine.config is not None and \
+                    self._experiment_engine.config.get("client") is not None and \
+                    self._experiment_engine.config["client"].get("passkey") != "":
                 self._experiment_engine.config["client"]["passkey"] = None
         else:
             self._experiment_engine = experiment_engine

--- a/sdk/turing/router/config/router_config.py
+++ b/sdk/turing/router/config/router_config.py
@@ -211,6 +211,12 @@ class RouterConfig:
             self._experiment_engine = experiment_engine
         elif isinstance(experiment_engine, dict):
             self._experiment_engine = ExperimentConfig(**experiment_engine)
+            # This block sets the passkey (encrypted when retrieved from the Turing API server) to None to prevent users
+            # from sending a router config with an already encrypted passkey back to API server when updating a router.
+            #
+            # When the passkey value is not set, the Turing API server is able to automatically retrieve the correct
+            # passkey from the existing router version (assuming it has been configured with the same standard
+            # experiment engine and the same client username).
             if self._experiment_engine.config is not None and \
                     self._experiment_engine.config.get("client") is not None and \
                     self._experiment_engine.config["client"].get("passkey") != "":


### PR DESCRIPTION
## Context
When using the UI to update an existing router that has an experiment engine configured, the passkey field is rendered as a dummy [text](https://github.com/caraml-dev/turing/blob/84339fa1c440ee923c0137eea073a1068479a58f/ui/src/services/experiment_engine/ExperimentEngine.js#L24) `"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"` even though in reality, the UI receives the value of the encrypted passkey through a GET request to the API server. This is done so as to not reveal any passkey, encrypted or not. If this dummy value is not overwritten in the update, the passkey of the current router version (if it exists) is automatically reused in the new router version. This happens because the passkey (encrypted by the API server) that's in the existing router version gets replaced by the UI with an empty string `""` just before it gets copied and sent in the request payload to the API server to update the router version. The API server then recognises this as a sign to reuse the existing router version's encrypted passkey from the DB in the new router version.

However, if the passkey has been changed, the UI simply sends the new passkey in the request payload to the API server, which then encrypts it before saving it within the DB.

On the other hand, this is not what happens in the SDK. While the SDK also retrieves the encrypted passkey from the same GET request to the API server, it instead exposes the encrypted passkey as an nested attribute of a `RouterConfig` object. While this necessarily too much of a problem, what's worse is that running the following code to update an existing router,
```python
router.update(router.config)
```
causes the encrypted passkey to be passed to the API server in its PUT request payload, _**as if the passkey were an unencrypted passkey**_. The API server then not only encrypts this already-encrypted passkey again and stores it in the DB, but also passes this double-encrypted passkey to the configured experiment engine without decrypting it correctly, causing errors downstream when this passkey doesn't get recognised. 

## Fix
In order to address the problem described above, this PR introduces one additional step when the SDK retrieves router configs from the API server - it sets the passkey field (if it exists) of the experiment engine config object as `None`. This not only emulates the behaviour of the UI to hide the (encrypted) value from the end user, but also ensures that if this specific experiment engine object gets reused to update a router, like in the code snippet above, an empty string `""` gets sent to the API server, allowing it to know that the passkey of the existing router version should be used instead.

Updating the passkey would be the same before - one just needs to manually set the passkey field with their unencrypted passkey and the API server would perform the encryption as usual.

## Miscellaneous 
It seems like a new version of `pytest` (`>=8.2.0`) has been released recently, causing many of our tests written in Python to fail in our CICD pipeline due to some breaking changes. I've pinned maximum version numbers for the affected packages since I haven't had time to carefully study the changes to refactor these tests.

cc @shydefoo 