### PR TITLE
fix(api): Refactor JobState to string

### DIFF
--- a/api/turing/api/ensembler_images_api.go
+++ b/api/turing/api/ensembler_images_api.go
@@ -67,7 +67,6 @@ func (c EnsemblerImagesController) BuildImage(
 	if err != nil {
 		return InternalServerError("unable to get MLP project for the router", err.Error())
 	}
-	log.Infof("project: %v", project)
 
 	ensembler, err := c.EnsemblersService.FindByID(
 		*options.EnsemblerID,
@@ -87,7 +86,7 @@ func (c EnsemblerImagesController) BuildImage(
 
 	go func() {
 		if err := c.EnsemblerImagesService.BuildImage(project, pyFuncEnsembler, request.RunnerType); err != nil {
-			log.Errorf("unable to build ensembler image", err.Error())
+			log.Errorf("unable to build ensembler image: %s", err.Error())
 		}
 	}()
 

--- a/api/turing/imagebuilder/imagebuilder.go
+++ b/api/turing/imagebuilder/imagebuilder.go
@@ -51,7 +51,7 @@ func (js JobStatus) IsActive() bool {
 	return js.State == JobStateActive
 }
 
-type JobState int
+type JobState string
 
 const (
 	// jobDeletionTimeoutInSeconds is the maximum time to wait for a job to be deleted from a cluster
@@ -60,14 +60,17 @@ const (
 	jobDeletionTickDurationInMilliseconds = 100
 	// jobCompletionTickDurationInSeconds is the interval at which the API server checks if a job has completed
 	jobCompletionTickDurationInSeconds = 5
+)
+
+const (
 	// JobStateActive is the status of the image building job is active
-	JobStateActive = JobState(iota)
-	// JobStateFailed is when the image building job has failed
-	JobStateFailed
+	JobStateActive JobState = "active"
 	// JobStateSucceeded is when the image building job has succeeded
-	JobStateSucceeded
+	JobStateSucceeded JobState = "succeeded"
+	// JobStateFailed is when the image building job has failed
+	JobStateFailed JobState = "failed"
 	// JobStateUnknown is when the image building job status is unknown
-	JobStateUnknown
+	JobStateUnknown JobState = "unknown"
 )
 
 // BuildImageRequest contains the information needed to build the OCI image


### PR DESCRIPTION
The previous JobState is `int` and uses `iota` together in the same const block with other values. This lead to JobState is starting from 3 instead of 0.

Using `int` for `JobState` requires mapping implementation in SDK.

This PR refactors JobState from `int` to `string` so that it easier to parse by SDK and to make it consistent with Merlin implementation (https://github.com/caraml-dev/merlin/blob/main/api/models/version_image.go#L15-L20).