### PR TITLE
fix(ui): Fix incorrect steps to remove ensembler fields 

### DIFF
--- a/ui/src/services/ensembler/Ensembler.js
+++ b/ui/src/services/ensembler/Ensembler.js
@@ -27,6 +27,9 @@ export class Ensembler {
   toJSON() {
     switch (this.type) {
       case "docker":
+        if (this.docker_config.resource_request?.cpu_limit === "") {
+          delete this.docker_config.resource_request.cpu_limit;
+        }
         return { type: this.type, docker_config: this.docker_config };
       case "standard":
         if (this.standard_config.experiment_mappings?.length === 0) {
@@ -35,11 +38,15 @@ export class Ensembler {
         if (this.standard_config.route_name_path === "") {
           delete this.standard_config.route_name_path;
         }
+        delete this.standard_config.fallback_response_route_id;
         return { type: this.type, standard_config: this.standard_config };
       case "pyfunc":
+        if (this.pyfunc_config.resource_request?.cpu_limit === "") {
+          delete this.pyfunc_config.resource_request.cpu_limit;
+        }
         return { type: this.type, pyfunc_config: this.pyfunc_config };
       default:
-        return { ...this, nop_config: this.nop_config };
+        return undefined;
     }
   }
 }

--- a/ui/src/services/router/TuringRouter.js
+++ b/ui/src/services/router/TuringRouter.js
@@ -138,25 +138,13 @@ export class TuringRouter {
       // Copy the final response route id to the top level, as the default route
       obj.config.default_route_id =
         obj.config["ensembler"].nop_config["final_response_route_id"];
-      delete obj.config["ensembler"];
     } else if (obj.config.ensembler.type === "standard") {
       // Copy the fallback response route id to the top level, as the default route
       obj.config.default_route_id =
         obj.config["ensembler"].standard_config["fallback_response_route_id"];
-      delete obj.config["ensembler"].standard_config[
-        "fallback_response_route_id"
-      ];
     } else {
       // Docker or Pyfunc ensembler, clear the default_route_id
       delete obj.config["default_route_id"];
-      if (obj.config.ensembler.type === "pyfunc") {
-        // Delete the docker config
-        delete obj.config["ensembler"].docker_config;
-      }
-      // Docker/Pyfunc ensembler CPU limit
-      if (obj.config.ensembler.resource_request?.cpu_limit === "") {
-        delete obj.config.ensembler.resource_request.cpu_limit;
-      }
     }
 
     // Outcome Logging


### PR DESCRIPTION
## Context
Certain fields in a router's ensembler config need to be removed manually before being stringified into a JSON object that will be sent to the Turing API server as the payload in various HTTP calls (e.g. update router, create new router version, etc.):
- `ensembler` (the entire ensembler config)
- `ensembler.standard_config.fallback_response_route_id` 
- `ensembler.docker_config`
- `ensembler.docker_config.resource_request.cpu_limit` / `ensembler.pyfunc_config.resource_request.cpu_limit` 

This was previously handled in the `toJson` method of the a `TuringRouter` object which gets called when `JSON.stringify` gets called on the `TuringRouter` object. However, in reality, this **did not remove any of the ensembler configs** listed above.

When `JSON.stringify` gets called on an object (`TuringRouter`) that has nested objects which also have their own `toJson` methods implemented (`Ensembler`), `JSON.stringify` actually calls `toJSON` recursively from the original object all the way down to their nested objects. However, because we actually perform a deep copy of the `TuringRouter` object in `toJSON`, we actually also copy a bounded `toJSON` belonging to its ensembler. As such, even when we try to delete fields in the deep copied router's ensembler, nothing happens because the bounded `toJSON` gets called, and returns all fields as part of the original ensembler.

For example, given an instance of the class `Parent`:
```js
class Parent {
  constructor() {
    this.name = "David";
    this.child = new Child();
  }

  toJSON() {
    // this is done to deep clone the Parent object
    const tmp = {};
    tmp.name = this.name;
    tmp.child = { name: this.child.name, toJSON: this.child.toJSON };

    // this does not delete anything because even though tmp.child.toJSON will be called to return the JSON string
    // for the child attribute, tmp.child.toJSON is actually bounded to this.child which does not have its name
    // deleted, thus the name will still show up in the final output
    delete tmp.child.name;
    return tmp;
  }
}

class Child {
  constructor() {
    this.name = "Goliath";
    // this binding ensures that anyone that copies the toJSON method will always call toJSON on this specific instance
    this.toJSON = this.toJSON.bind(this);
  }

  toJSON() {
    // does nothing; just returns all fields faithfully
    return this;
  }
}

someone = new Parent();
console.log(JSON.stringify(someone)); 

// OUTPUT: {"name":"David","child":{"name":"Goliath"}}
```

As such, this is some conflicting behaviour as a result of us performing both the deep-cloning AND the binding of `toJSON`, which (unexpectedly or not) caused the bounded `toJSON` function to be cloned and used. Of course we can either: 1) not clone the bounded `toJSON` function, but this is hard since we're using a deep cloning library, and if we don't clone `toJSON`, we still need to replicate the logic contained within it, or 2) don't bind `toJSON` but I don't know what the original intent of the binding is for, and removing it might break other stuff unexpectedly.

As such, I'll simply move all the ensembler-related deletion logic into the `toJSON` method of the ensembler to ensure that all the necessary fields get removed properly, without having to deal with either the cloning library or the binding.
