### PR TITLE
feat(ui): Add stackdriver links to logs tab

### DIFF
--- a/ui/src/components/pod_logs_viewer/PodLogsViewer.js
+++ b/ui/src/components/pod_logs_viewer/PodLogsViewer.js
@@ -4,6 +4,9 @@ import {
   EuiFlexItem,
   EuiSearchBar,
   EuiSpacer,
+  EuiPanel,
+  EuiText,
+  EuiLink
 } from "@elastic/eui";
 import { LazyLog, ScrollFollow } from "react-lazylog";
 import { slugify } from "@caraml-dev/ui-lib";
@@ -17,6 +20,7 @@ export const PodLogsViewer = ({
   query,
   onQueryChange,
   batchSize,
+  stackdriverUrls,
 }) => {
   const filters = useMemo(
     () => [
@@ -110,33 +114,59 @@ export const PodLogsViewer = ({
   };
 
   return (
-    <EuiFlexGroup
-      direction="column"
-      gutterSize="none"
-      className="euiFlexGroup---logsContainer">
-      <EuiFlexItem grow={false}>
-        <EuiSearchBar {...search} />
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <EuiSpacer size="s" />
-      </EuiFlexItem>
-      <EuiFlexItem grow={true}>
-        <ScrollFollow
-          startFollowing={true}
-          render={({ onScroll, follow }) => (
-            <LazyLog
-              key={slugify(searchQuery)}
-              eventSource={emitter}
-              extraLines={1}
-              onScroll={onScroll}
-              follow={follow}
-              caseInsensitive
-              enableSearch
-              selectableLines
+    <>
+      {
+        Object.keys(stackdriverUrls).length !== 0 &&
+        (
+          <>
+            <EuiPanel>
+              <EuiFlexGroup direction="row" alignItems="center">
+                <EuiFlexItem style={{marginTop:0, marginBottom:0}} grow={false}>
+                  <EuiText  style={{ fontSize: '14px', fontWeight:"bold"}}>Stackdriver Logs</EuiText>
+                </EuiFlexItem>
+                {Object.entries(stackdriverUrls).map(([component,url])=> (
+                  <EuiFlexItem style={{marginTop:0, marginBottom:0, paddingLeft:"10px", textTransform: "capitalize"}} key={component} grow={false}>
+                    <EuiText size="xs" >
+                      <EuiLink href={url} target="_blank" external>{component.replace(new RegExp("_", "g"), " ")}</EuiLink>
+                    </EuiText>
+                  </EuiFlexItem>
+                ))}
+              </EuiFlexGroup>
+            </EuiPanel>
+            <EuiSpacer size="s" />
+          </>
+        )
+      }
+      <EuiPanel>
+        <EuiFlexGroup
+          direction="column"
+          gutterSize="none"
+          className="euiFlexGroup---logsContainer">
+          <EuiFlexItem grow={false}>
+            <EuiSearchBar {...search} />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiSpacer size="s" />
+          </EuiFlexItem>
+          <EuiFlexItem grow={true}>
+            <ScrollFollow
+              startFollowing={true}
+              render={({ onScroll, follow }) => (
+                <LazyLog
+                  key={slugify(searchQuery)}
+                  eventSource={emitter}
+                  extraLines={1}
+                  onScroll={onScroll}
+                  follow={follow}
+                  caseInsensitive
+                  enableSearch
+                  selectableLines
+                />
+              )}
             />
-          )}
-        />
-      </EuiFlexItem>
-    </EuiFlexGroup>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPanel>
+    </>
   );
 };

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -31,7 +31,7 @@ const authConfig = {
   oauthClientId: process.env.REACT_APP_OAUTH_CLIENT_ID,
 };
 
-const appConfig = {
+export const appConfig = {
   environment: process.env.REACT_APP_ENVIRONMENT,
   homepage: process.env.PUBLIC_URL,
   appIcon: "graphApp",

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -60,6 +60,11 @@ const appConfig = {
     // Default number of tail log entries to be fetched
     defaultTailLines: 1000,
   },
+  imagebuilder: {
+    cluster:  process.env.REACT_APP_IMAGE_BUILDER_CLUSTER,
+    gcp_project: process.env.REACT_APP_IMAGE_BUILDER_GCP_PROJECT,
+    namespace: process.env.REACT_APP_IMAGE_BUILDER_NAMESPACE,
+  },
   // Specifies a set of page templating configurations that will soon be controlled by the mlp-ui package
   // TO-DO: to review if these set of specifications are still needed after the update to mlp-ui
   pageTemplate: {

--- a/ui/src/router/details/RouterDetailsView.js
+++ b/ui/src/router/details/RouterDetailsView.js
@@ -24,6 +24,7 @@ import { RouterLogsView } from "./logs/RouterLogsView";
 import { VersionComparisonView } from "../versions/comparison/VersionComparisonView";
 import { TuringRouter } from "../../services/router/TuringRouter";
 import { useConfig } from "../../config";
+import { EnsemblersContextProvider } from "../../providers/ensemblers/context";
 
 export const RouterDetailsView = () => {
   const { projectId, routerId, "*": section } = useParams();
@@ -131,7 +132,13 @@ export const RouterDetailsView = () => {
               {/* ALERTS */}
               <Route path="alerts/*" element={<RouterAlertsView router={router} />} />
               {/* LOGS */}
-              <Route path="logs" element={<RouterLogsView router={router} />} />
+              <Route path="logs" element={
+                <EnsemblersContextProvider
+                  projectId={router.project_id}
+                  ensemblerType={"pyfunc"}>
+                  <RouterLogsView router={router} />
+                </EnsemblersContextProvider>
+              } />
             </Routes>
           </EuiPageTemplate.Section>
         </Fragment>

--- a/ui/src/router/details/logs/RouterLogsView.js
+++ b/ui/src/router/details/logs/RouterLogsView.js
@@ -90,7 +90,7 @@ export const RouterLogsView = ({ router }) => {
           namespace: currentProject.name,
           pod_name: router.name + "-turing-router-"  + router.config.version,
           start_time: router.updated_at,
-        }, "router", appConfig.imagebuilder)
+        }, "router")
 
         // set enricher url
         if (router.config.enricher.type === "docker") {
@@ -100,7 +100,7 @@ export const RouterLogsView = ({ router }) => {
             namespace: currentProject.name,
             pod_name: router.name + "-turing-enricher-" + router.config.version,
             start_time: router.updated_at,
-          }, "enricher", appConfig.imagebuilder)
+          }, "enricher")
         }
 
         // set ensembler url
@@ -111,7 +111,7 @@ export const RouterLogsView = ({ router }) => {
             namespace: currentProject.name,
             pod_name: router.name + "-turing-ensembler-" + router.config.version,
             start_time: router.updated_at,
-          }, "ensembler", appConfig.imagebuilder)
+          }, "ensembler")
         }
 
         // set image builder url
@@ -119,7 +119,7 @@ export const RouterLogsView = ({ router }) => {
           urls["ensembler_image_builder"] = createStackdriverUrl({
             job_name: "service-" + currentProject.name + "-" + ensembler.name,
             start_time: ensembler.updated_at,
-          }, "ensembler_image_builder", appConfig.imagebuilder)
+          }, "ensembler_image_builder")
         }
 
         setStackdriverUrls(urls);

--- a/ui/src/router/details/logs/RouterLogsView.js
+++ b/ui/src/router/details/logs/RouterLogsView.js
@@ -77,8 +77,12 @@ export const RouterLogsView = ({ router }) => {
   useEffect(
     () => {
       let urls = {}
-      if (appConfig.imagebuilder.cluster && appConfig.imagebuilder.gcp_project && appConfig.imagebuilder.namespace &&
-        currentProject) {
+      if (
+          appConfig.imagebuilder.cluster &&
+          appConfig.imagebuilder.gcp_project &&
+          appConfig.imagebuilder.namespace &&
+          currentProject
+      ) {
         // set router url
         urls["router"] = createStackdriverUrl({
           gcp_project: environment.gcp_project,

--- a/ui/src/utils/createStackdriverUrl.js
+++ b/ui/src/utils/createStackdriverUrl.js
@@ -1,5 +1,7 @@
 // This file in almost an exact copy of this file from Merlin
 // Ref: https://github.com/caraml-dev/merlin/blob/8edef22b29d0bfb2728d62b1f880f1f753f9509e/ui/src/utils/createStackdriverUrl.js
+import { appConfig } from "../config";
+
 const stackdriverAPI = "https://console.cloud.google.com/logs/viewer";
 
 const stackdriverFilter = query => {
@@ -12,20 +14,20 @@ timestamp>"${query.start_time}"
 `;
 };
 
-const stackdriverImageBuilderFilter =  (query, imagebuilder) => {
+const stackdriverImageBuilderFilter =  query => {
   return `resource.type:"k8s_container"
-resource.labels.project_id:${imagebuilder.gcp_project}
-resource.labels.cluster_name:${imagebuilder.cluster}
-resource.labels.namespace_name:${imagebuilder.namespace}
+resource.labels.project_id:${appConfig.imagebuilder.gcp_project}
+resource.labels.cluster_name:${appConfig.imagebuilder.cluster}
+resource.labels.namespace_name:${appConfig.imagebuilder.namespace}
 labels.k8s-pod/job-name:${query.job_name}
 timestamp>"${query.start_time}"`;
 }
 
-export const createStackdriverUrl = (query, component, imagebuilder) => {
-  const advanceFilter = component === "ensembler_image_builder" ? stackdriverImageBuilderFilter(query, imagebuilder) : stackdriverFilter(query);
+export const createStackdriverUrl = (query, component) => {
+  const advanceFilter = component === "ensembler_image_builder" ? stackdriverImageBuilderFilter(query) : stackdriverFilter(query);
 
   const url = {
-    project: query.gcp_project || imagebuilder.gcp_project,
+    project: query.gcp_project || appConfig.imagebuilder.gcp_project,
     minLogLevel: 0,
     expandAll: false,
     advancedFilter: advanceFilter,

--- a/ui/src/utils/createStackdriverUrl.js
+++ b/ui/src/utils/createStackdriverUrl.js
@@ -24,7 +24,6 @@ timestamp>"${query.start_time}"`;
 export const createStackdriverUrl = (query, component, imagebuilder) => {
   const advanceFilter = component === "ensembler_image_builder" ? stackdriverImageBuilderFilter(query, imagebuilder) : stackdriverFilter(query);
 
-  console.log(imagebuilder);
   const url = {
     project: query.gcp_project || imagebuilder.gcp_project,
     minLogLevel: 0,

--- a/ui/src/utils/createStackdriverUrl.js
+++ b/ui/src/utils/createStackdriverUrl.js
@@ -1,0 +1,36 @@
+const stackdriverAPI = "https://console.cloud.google.com/logs/viewer";
+
+const stackdriverFilter = query => {
+  return `resource.type:"k8s_query" OR "k8s_container" OR "k8s_pod"
+resource.labels.project_id:${query.gcp_project}
+resource.labels.cluster_name:${query.cluster}
+resource.labels.namespace_name:${query.namespace}
+resource.labels.pod_name:${query.pod_name}
+timestamp>"${query.start_time}"
+`;
+};
+
+const stackdriverImageBuilderFilter =  (query, imagebuilder) => {
+  return `resource.type:"k8s_container"
+resource.labels.project_id:${imagebuilder.gcp_project}
+resource.labels.cluster_name:${imagebuilder.cluster}
+resource.labels.namespace_name:${imagebuilder.namespace}
+labels.k8s-pod/job-name:${query.job_name}
+timestamp>"${query.start_time}"`;
+}
+
+export const createStackdriverUrl = (query, component, imagebuilder) => {
+  const advanceFilter = component === "ensembler_image_builder" ? stackdriverImageBuilderFilter(query, imagebuilder) : stackdriverFilter(query);
+
+  console.log(imagebuilder);
+  const url = {
+    project: query.gcp_project || imagebuilder.gcp_project,
+    minLogLevel: 0,
+    expandAll: false,
+    advancedFilter: advanceFilter,
+  };
+
+  const stackdriverParams = new URLSearchParams(url).toString();
+  return stackdriverAPI + "?" + stackdriverParams;
+};
+

--- a/ui/src/utils/createStackdriverUrl.js
+++ b/ui/src/utils/createStackdriverUrl.js
@@ -1,3 +1,5 @@
+// This file in almost an exact copy of this file from Merlin
+// Ref: https://github.com/caraml-dev/merlin/blob/8edef22b29d0bfb2728d62b1f880f1f753f9509e/ui/src/utils/createStackdriverUrl.js
 const stackdriverAPI = "https://console.cloud.google.com/logs/viewer";
 
 const stackdriverFilter = query => {


### PR DESCRIPTION
## Context
Similar to how the Merlin logs tab displays links to stored logs on stackdriver (Google Cloud Logging) in addition to live logs, this PR adds a panel to the router logs tab to display links to stored logs on stackdriver for the following components:
- router
- enricher (Docker enrichers only)
- ensembler (Docker and pyfunc ensemblers only)
- ensembler building logs (pyfunc ensemblers only)

![Screenshot 2024-06-12 at 12 37 09](https://github.com/caraml-dev/turing/assets/36802364/00675a78-2754-4a09-b149-35afc67bba64)