### PR TITLE
fix(api): Remove regex check for autoscaling target in autogenerated files

### DIFF
--- a/api/api/openapi.bundle.yaml
+++ b/api/api/openapi.bundle.yaml
@@ -2349,7 +2349,6 @@ components:
           - rps
           type: string
         target:
-          pattern: ^\d+$
           type: string
       type: object
     Protocol:

--- a/api/api/specs/routers.yaml
+++ b/api/api/specs/routers.yaml
@@ -969,7 +969,6 @@ components:
             - "rps"
         target:
           type: "string"
-          pattern: '^\d+$'
 
     BigQueryConfig:
       type: "object"

--- a/api/turing/generated/model_big_query_dataset.go
+++ b/api/turing/generated/model_big_query_dataset.go
@@ -16,7 +16,7 @@ import (
 
 // BigQueryDataset struct for BigQueryDataset
 type BigQueryDataset struct {
-	Type     string                `json:"type"`
+	Type string `json:"type"`
 	BqConfig BigQueryDatasetConfig `json:"bq_config"`
 }
 
@@ -54,7 +54,7 @@ func (o *BigQueryDataset) GetType() string {
 // GetTypeOk returns a tuple with the Type field value
 // and a boolean to check if the value has been set.
 func (o *BigQueryDataset) GetTypeOk() (*string, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.Type, true
@@ -78,7 +78,7 @@ func (o *BigQueryDataset) GetBqConfig() BigQueryDatasetConfig {
 // GetBqConfigOk returns a tuple with the BqConfig field value
 // and a boolean to check if the value has been set.
 func (o *BigQueryDataset) GetBqConfigOk() (*BigQueryDatasetConfig, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.BqConfig, true
@@ -135,3 +135,5 @@ func (v *NullableBigQueryDataset) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
+
+

--- a/api/turing/generated/model_big_query_dataset_config.go
+++ b/api/turing/generated/model_big_query_dataset_config.go
@@ -16,10 +16,10 @@ import (
 
 // BigQueryDatasetConfig struct for BigQueryDatasetConfig
 type BigQueryDatasetConfig struct {
-	Table    *string           `json:"table,omitempty"`
-	Features []string          `json:"features,omitempty"`
-	Query    *string           `json:"query,omitempty"`
-	Options  map[string]string `json:"options,omitempty"`
+	Table *string `json:"table,omitempty"`
+	Features []string `json:"features,omitempty"`
+	Query *string `json:"query,omitempty"`
+	Options map[string]string `json:"options,omitempty"`
 }
 
 // NewBigQueryDatasetConfig instantiates a new BigQueryDatasetConfig object
@@ -73,7 +73,7 @@ func (o *BigQueryDatasetConfig) SetTable(v string) {
 
 // GetFeatures returns the Features field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *BigQueryDatasetConfig) GetFeatures() []string {
-	if o == nil {
+	if o == nil  {
 		var ret []string
 		return ret
 	}
@@ -138,7 +138,7 @@ func (o *BigQueryDatasetConfig) SetQuery(v string) {
 
 // GetOptions returns the Options field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *BigQueryDatasetConfig) GetOptions() map[string]string {
-	if o == nil {
+	if o == nil  {
 		var ret map[string]string
 		return ret
 	}
@@ -221,3 +221,5 @@ func (v *NullableBigQueryDatasetConfig) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
+
+

--- a/api/turing/generated/model_big_query_sink.go
+++ b/api/turing/generated/model_big_query_sink.go
@@ -16,9 +16,9 @@ import (
 
 // BigQuerySink struct for BigQuerySink
 type BigQuerySink struct {
-	Type     string             `json:"type"`
-	Columns  []string           `json:"columns,omitempty"`
-	SaveMode SaveMode           `json:"save_mode"`
+	Type string `json:"type"`
+	Columns []string `json:"columns,omitempty"`
+	SaveMode SaveMode `json:"save_mode"`
 	BqConfig BigQuerySinkConfig `json:"bq_config"`
 }
 
@@ -57,7 +57,7 @@ func (o *BigQuerySink) GetType() string {
 // GetTypeOk returns a tuple with the Type field value
 // and a boolean to check if the value has been set.
 func (o *BigQuerySink) GetTypeOk() (*string, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.Type, true
@@ -70,7 +70,7 @@ func (o *BigQuerySink) SetType(v string) {
 
 // GetColumns returns the Columns field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *BigQuerySink) GetColumns() []string {
-	if o == nil {
+	if o == nil  {
 		var ret []string
 		return ret
 	}
@@ -114,7 +114,7 @@ func (o *BigQuerySink) GetSaveMode() SaveMode {
 // GetSaveModeOk returns a tuple with the SaveMode field value
 // and a boolean to check if the value has been set.
 func (o *BigQuerySink) GetSaveModeOk() (*SaveMode, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.SaveMode, true
@@ -138,7 +138,7 @@ func (o *BigQuerySink) GetBqConfig() BigQuerySinkConfig {
 // GetBqConfigOk returns a tuple with the BqConfig field value
 // and a boolean to check if the value has been set.
 func (o *BigQuerySink) GetBqConfigOk() (*BigQuerySinkConfig, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.BqConfig, true
@@ -201,3 +201,5 @@ func (v *NullableBigQuerySink) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
+
+

--- a/api/turing/generated/model_big_query_sink_config.go
+++ b/api/turing/generated/model_big_query_sink_config.go
@@ -16,9 +16,9 @@ import (
 
 // BigQuerySinkConfig struct for BigQuerySinkConfig
 type BigQuerySinkConfig struct {
-	Table         string            `json:"table"`
-	StagingBucket string            `json:"staging_bucket"`
-	Options       map[string]string `json:"options,omitempty"`
+	Table string `json:"table"`
+	StagingBucket string `json:"staging_bucket"`
+	Options map[string]string `json:"options,omitempty"`
 }
 
 // NewBigQuerySinkConfig instantiates a new BigQuerySinkConfig object
@@ -53,7 +53,7 @@ func (o *BigQuerySinkConfig) GetTable() string {
 // GetTableOk returns a tuple with the Table field value
 // and a boolean to check if the value has been set.
 func (o *BigQuerySinkConfig) GetTableOk() (*string, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.Table, true
@@ -77,7 +77,7 @@ func (o *BigQuerySinkConfig) GetStagingBucket() string {
 // GetStagingBucketOk returns a tuple with the StagingBucket field value
 // and a boolean to check if the value has been set.
 func (o *BigQuerySinkConfig) GetStagingBucketOk() (*string, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.StagingBucket, true
@@ -90,7 +90,7 @@ func (o *BigQuerySinkConfig) SetStagingBucket(v string) {
 
 // GetOptions returns the Options field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *BigQuerySinkConfig) GetOptions() map[string]string {
-	if o == nil {
+	if o == nil  {
 		var ret map[string]string
 		return ret
 	}
@@ -170,3 +170,5 @@ func (v *NullableBigQuerySinkConfig) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
+
+

--- a/api/turing/generated/model_dataset.go
+++ b/api/turing/generated/model_dataset.go
@@ -22,8 +22,9 @@ type Dataset struct {
 
 // BigQueryDatasetAsDataset is a convenience function that returns BigQueryDataset wrapped in Dataset
 func BigQueryDatasetAsDataset(v *BigQueryDataset) Dataset {
-	return Dataset{BigQueryDataset: v}
+	return Dataset{ BigQueryDataset: v}
 }
+
 
 // Unmarshal JSON data into one of the pointers in the struct
 func (dst *Dataset) UnmarshalJSON(data []byte) error {
@@ -64,7 +65,7 @@ func (src Dataset) MarshalJSON() ([]byte, error) {
 }
 
 // Get the actual instance
-func (obj *Dataset) GetActualInstance() interface{} {
+func (obj *Dataset) GetActualInstance() (interface{}) {
 	if obj.BigQueryDataset != nil {
 		return obj.BigQueryDataset
 	}
@@ -108,3 +109,5 @@ func (v *NullableDataset) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
+
+

--- a/api/turing/generated/model_ensembler_config.go
+++ b/api/turing/generated/model_ensembler_config.go
@@ -16,10 +16,10 @@ import (
 
 // EnsemblerConfig struct for EnsemblerConfig
 type EnsemblerConfig struct {
-	Version  string              `json:"version"`
-	Kind     EnsemblerConfigKind `json:"kind"`
-	Metadata *EnsemblingJobMeta  `json:"metadata,omitempty"`
-	Spec     EnsemblingJobSpec   `json:"spec"`
+	Version string `json:"version"`
+	Kind EnsemblerConfigKind `json:"kind"`
+	Metadata *EnsemblingJobMeta `json:"metadata,omitempty"`
+	Spec EnsemblingJobSpec `json:"spec"`
 }
 
 // NewEnsemblerConfig instantiates a new EnsemblerConfig object
@@ -55,7 +55,7 @@ func (o *EnsemblerConfig) GetVersion() string {
 // GetVersionOk returns a tuple with the Version field value
 // and a boolean to check if the value has been set.
 func (o *EnsemblerConfig) GetVersionOk() (*string, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.Version, true
@@ -79,7 +79,7 @@ func (o *EnsemblerConfig) GetKind() EnsemblerConfigKind {
 // GetKindOk returns a tuple with the Kind field value
 // and a boolean to check if the value has been set.
 func (o *EnsemblerConfig) GetKindOk() (*EnsemblerConfigKind, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.Kind, true
@@ -135,7 +135,7 @@ func (o *EnsemblerConfig) GetSpec() EnsemblingJobSpec {
 // GetSpecOk returns a tuple with the Spec field value
 // and a boolean to check if the value has been set.
 func (o *EnsemblerConfig) GetSpecOk() (*EnsemblingJobSpec, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.Spec, true
@@ -198,3 +198,5 @@ func (v *NullableEnsemblerConfig) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
+
+

--- a/api/turing/generated/model_ensembler_config_kind.go
+++ b/api/turing/generated/model_ensembler_config_kind.go
@@ -105,3 +105,4 @@ func (v *NullableEnsemblerConfigKind) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
+

--- a/api/turing/generated/model_ensembler_infra_config.go
+++ b/api/turing/generated/model_ensembler_infra_config.go
@@ -16,12 +16,12 @@ import (
 
 // EnsemblerInfraConfig struct for EnsemblerInfraConfig
 type EnsemblerInfraConfig struct {
-	ArtifactUri        *string                     `json:"artifact_uri,omitempty"`
-	EnsemblerName      *string                     `json:"ensembler_name,omitempty"`
-	ServiceAccountName *string                     `json:"service_account_name,omitempty" validate:"required"`
-	Resources          NullableEnsemblingResources `json:"resources,omitempty"`
-	RunId              *string                     `json:"run_id,omitempty"`
-	Env                *[]EnvVar                   `json:"env,omitempty"`
+	ArtifactUri *string `json:"artifact_uri,omitempty"`
+	EnsemblerName *string `json:"ensembler_name,omitempty"`
+	ServiceAccountName *string `json:"service_account_name,omitempty" validate:"required"`
+	Resources NullableEnsemblingResources `json:"resources,omitempty"`
+	RunId *string `json:"run_id,omitempty"`
+	Env *[]EnvVar `json:"env,omitempty"`
 }
 
 // NewEnsemblerInfraConfig instantiates a new EnsemblerInfraConfig object
@@ -150,7 +150,7 @@ func (o *EnsemblerInfraConfig) GetResources() EnsemblingResources {
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *EnsemblerInfraConfig) GetResourcesOk() (*EnsemblingResources, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return o.Resources.Get(), o.Resources.IsSet()
@@ -169,7 +169,6 @@ func (o *EnsemblerInfraConfig) HasResources() bool {
 func (o *EnsemblerInfraConfig) SetResources(v EnsemblingResources) {
 	o.Resources.Set(&v)
 }
-
 // SetResourcesNil sets the value for Resources to be an explicit nil
 func (o *EnsemblerInfraConfig) SetResourcesNil() {
 	o.Resources.Set(nil)
@@ -302,3 +301,5 @@ func (v *NullableEnsemblerInfraConfig) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
+
+

--- a/api/turing/generated/model_ensembling_job_ensembler_spec.go
+++ b/api/turing/generated/model_ensembling_job_ensembler_spec.go
@@ -16,7 +16,7 @@ import (
 
 // EnsemblingJobEnsemblerSpec struct for EnsemblingJobEnsemblerSpec
 type EnsemblingJobEnsemblerSpec struct {
-	Uri    string                           `json:"uri"`
+	Uri string `json:"uri"`
 	Result EnsemblingJobEnsemblerSpecResult `json:"result"`
 }
 
@@ -54,7 +54,7 @@ func (o *EnsemblingJobEnsemblerSpec) GetUri() string {
 // GetUriOk returns a tuple with the Uri field value
 // and a boolean to check if the value has been set.
 func (o *EnsemblingJobEnsemblerSpec) GetUriOk() (*string, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.Uri, true
@@ -78,7 +78,7 @@ func (o *EnsemblingJobEnsemblerSpec) GetResult() EnsemblingJobEnsemblerSpecResul
 // GetResultOk returns a tuple with the Result field value
 // and a boolean to check if the value has been set.
 func (o *EnsemblingJobEnsemblerSpec) GetResultOk() (*EnsemblingJobEnsemblerSpecResult, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.Result, true
@@ -135,3 +135,5 @@ func (v *NullableEnsemblingJobEnsemblerSpec) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
+
+

--- a/api/turing/generated/model_ensembling_job_ensembler_spec_result.go
+++ b/api/turing/generated/model_ensembling_job_ensembler_spec_result.go
@@ -16,9 +16,9 @@ import (
 
 // EnsemblingJobEnsemblerSpecResult struct for EnsemblingJobEnsemblerSpecResult
 type EnsemblingJobEnsemblerSpecResult struct {
-	Type       EnsemblingJobResultType  `json:"type"`
-	ItemType   *EnsemblingJobResultType `json:"item_type,omitempty"`
-	ColumnName string                   `json:"column_name"`
+	Type EnsemblingJobResultType `json:"type"`
+	ItemType *EnsemblingJobResultType `json:"item_type,omitempty"`
+	ColumnName string `json:"column_name"`
 }
 
 // NewEnsemblingJobEnsemblerSpecResult instantiates a new EnsemblingJobEnsemblerSpecResult object
@@ -53,7 +53,7 @@ func (o *EnsemblingJobEnsemblerSpecResult) GetType() EnsemblingJobResultType {
 // GetTypeOk returns a tuple with the Type field value
 // and a boolean to check if the value has been set.
 func (o *EnsemblingJobEnsemblerSpecResult) GetTypeOk() (*EnsemblingJobResultType, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.Type, true
@@ -109,7 +109,7 @@ func (o *EnsemblingJobEnsemblerSpecResult) GetColumnName() string {
 // GetColumnNameOk returns a tuple with the ColumnName field value
 // and a boolean to check if the value has been set.
 func (o *EnsemblingJobEnsemblerSpecResult) GetColumnNameOk() (*string, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.ColumnName, true
@@ -169,3 +169,5 @@ func (v *NullableEnsemblingJobEnsemblerSpecResult) UnmarshalJSON(src []byte) err
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
+
+

--- a/api/turing/generated/model_ensembling_job_meta.go
+++ b/api/turing/generated/model_ensembling_job_meta.go
@@ -16,7 +16,7 @@ import (
 
 // EnsemblingJobMeta Ensembling job Metadata
 type EnsemblingJobMeta struct {
-	Name        string            `json:"name"`
+	Name string `json:"name"`
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
@@ -51,7 +51,7 @@ func (o *EnsemblingJobMeta) GetName() string {
 // GetNameOk returns a tuple with the Name field value
 // and a boolean to check if the value has been set.
 func (o *EnsemblingJobMeta) GetNameOk() (*string, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.Name, true
@@ -64,7 +64,7 @@ func (o *EnsemblingJobMeta) SetName(v string) {
 
 // GetAnnotations returns the Annotations field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *EnsemblingJobMeta) GetAnnotations() map[string]string {
-	if o == nil {
+	if o == nil  {
 		var ret map[string]string
 		return ret
 	}
@@ -141,3 +141,5 @@ func (v *NullableEnsemblingJobMeta) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
+
+

--- a/api/turing/generated/model_ensembling_job_prediction_source.go
+++ b/api/turing/generated/model_ensembling_job_prediction_source.go
@@ -16,8 +16,8 @@ import (
 
 // EnsemblingJobPredictionSource struct for EnsemblingJobPredictionSource
 type EnsemblingJobPredictionSource struct {
-	Dataset Dataset  `json:"dataset"`
-	JoinOn  []string `json:"join_on"`
+	Dataset Dataset `json:"dataset"`
+	JoinOn []string `json:"join_on"`
 	Columns []string `json:"columns,omitempty"`
 }
 
@@ -53,7 +53,7 @@ func (o *EnsemblingJobPredictionSource) GetDataset() Dataset {
 // GetDatasetOk returns a tuple with the Dataset field value
 // and a boolean to check if the value has been set.
 func (o *EnsemblingJobPredictionSource) GetDatasetOk() (*Dataset, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.Dataset, true
@@ -77,7 +77,7 @@ func (o *EnsemblingJobPredictionSource) GetJoinOn() []string {
 // GetJoinOnOk returns a tuple with the JoinOn field value
 // and a boolean to check if the value has been set.
 func (o *EnsemblingJobPredictionSource) GetJoinOnOk() (*[]string, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.JoinOn, true
@@ -90,7 +90,7 @@ func (o *EnsemblingJobPredictionSource) SetJoinOn(v []string) {
 
 // GetColumns returns the Columns field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *EnsemblingJobPredictionSource) GetColumns() []string {
-	if o == nil {
+	if o == nil  {
 		var ret []string
 		return ret
 	}
@@ -170,3 +170,5 @@ func (v *NullableEnsemblingJobPredictionSource) UnmarshalJSON(src []byte) error 
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
+
+

--- a/api/turing/generated/model_ensembling_job_result_type.go
+++ b/api/turing/generated/model_ensembling_job_result_type.go
@@ -20,12 +20,12 @@ type EnsemblingJobResultType string
 
 // List of EnsemblingJobResultType
 const (
-	ENSEMBLINGJOBRESULTTYPE_DOUBLE  EnsemblingJobResultType = "DOUBLE"
-	ENSEMBLINGJOBRESULTTYPE_FLOAT   EnsemblingJobResultType = "FLOAT"
+	ENSEMBLINGJOBRESULTTYPE_DOUBLE EnsemblingJobResultType = "DOUBLE"
+	ENSEMBLINGJOBRESULTTYPE_FLOAT EnsemblingJobResultType = "FLOAT"
 	ENSEMBLINGJOBRESULTTYPE_INTEGER EnsemblingJobResultType = "INTEGER"
-	ENSEMBLINGJOBRESULTTYPE_LONG    EnsemblingJobResultType = "LONG"
-	ENSEMBLINGJOBRESULTTYPE_STRING  EnsemblingJobResultType = "STRING"
-	ENSEMBLINGJOBRESULTTYPE_ARRAY   EnsemblingJobResultType = "ARRAY"
+	ENSEMBLINGJOBRESULTTYPE_LONG EnsemblingJobResultType = "LONG"
+	ENSEMBLINGJOBRESULTTYPE_STRING EnsemblingJobResultType = "STRING"
+	ENSEMBLINGJOBRESULTTYPE_ARRAY EnsemblingJobResultType = "ARRAY"
 )
 
 var allowedEnsemblingJobResultTypeEnumValues = []EnsemblingJobResultType{
@@ -115,3 +115,4 @@ func (v *NullableEnsemblingJobResultType) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
+

--- a/api/turing/generated/model_ensembling_job_sink.go
+++ b/api/turing/generated/model_ensembling_job_sink.go
@@ -22,8 +22,9 @@ type EnsemblingJobSink struct {
 
 // BigQuerySinkAsEnsemblingJobSink is a convenience function that returns BigQuerySink wrapped in EnsemblingJobSink
 func BigQuerySinkAsEnsemblingJobSink(v *BigQuerySink) EnsemblingJobSink {
-	return EnsemblingJobSink{BigQuerySink: v}
+	return EnsemblingJobSink{ BigQuerySink: v}
 }
+
 
 // Unmarshal JSON data into one of the pointers in the struct
 func (dst *EnsemblingJobSink) UnmarshalJSON(data []byte) error {
@@ -64,7 +65,7 @@ func (src EnsemblingJobSink) MarshalJSON() ([]byte, error) {
 }
 
 // Get the actual instance
-func (obj *EnsemblingJobSink) GetActualInstance() interface{} {
+func (obj *EnsemblingJobSink) GetActualInstance() (interface{}) {
 	if obj.BigQuerySink != nil {
 		return obj.BigQuerySink
 	}
@@ -108,3 +109,5 @@ func (v *NullableEnsemblingJobSink) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
+
+

--- a/api/turing/generated/model_ensembling_job_source.go
+++ b/api/turing/generated/model_ensembling_job_source.go
@@ -16,8 +16,8 @@ import (
 
 // EnsemblingJobSource struct for EnsemblingJobSource
 type EnsemblingJobSource struct {
-	Dataset Dataset  `json:"dataset"`
-	JoinOn  []string `json:"join_on"`
+	Dataset Dataset `json:"dataset"`
+	JoinOn []string `json:"join_on"`
 }
 
 // NewEnsemblingJobSource instantiates a new EnsemblingJobSource object
@@ -52,7 +52,7 @@ func (o *EnsemblingJobSource) GetDataset() Dataset {
 // GetDatasetOk returns a tuple with the Dataset field value
 // and a boolean to check if the value has been set.
 func (o *EnsemblingJobSource) GetDatasetOk() (*Dataset, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.Dataset, true
@@ -76,7 +76,7 @@ func (o *EnsemblingJobSource) GetJoinOn() []string {
 // GetJoinOnOk returns a tuple with the JoinOn field value
 // and a boolean to check if the value has been set.
 func (o *EnsemblingJobSource) GetJoinOnOk() (*[]string, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.JoinOn, true
@@ -133,3 +133,5 @@ func (v *NullableEnsemblingJobSource) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
+
+

--- a/api/turing/generated/model_ensembling_job_spec.go
+++ b/api/turing/generated/model_ensembling_job_spec.go
@@ -16,10 +16,10 @@ import (
 
 // EnsemblingJobSpec Ensembling job Specification
 type EnsemblingJobSpec struct {
-	Source      EnsemblingJobSource                      `json:"source"`
+	Source EnsemblingJobSource `json:"source"`
 	Predictions map[string]EnsemblingJobPredictionSource `json:"predictions"`
-	Ensembler   EnsemblingJobEnsemblerSpec               `json:"ensembler"`
-	Sink        EnsemblingJobSink                        `json:"sink"`
+	Ensembler EnsemblingJobEnsemblerSpec `json:"ensembler"`
+	Sink EnsemblingJobSink `json:"sink"`
 }
 
 // NewEnsemblingJobSpec instantiates a new EnsemblingJobSpec object
@@ -56,7 +56,7 @@ func (o *EnsemblingJobSpec) GetSource() EnsemblingJobSource {
 // GetSourceOk returns a tuple with the Source field value
 // and a boolean to check if the value has been set.
 func (o *EnsemblingJobSpec) GetSourceOk() (*EnsemblingJobSource, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.Source, true
@@ -80,7 +80,7 @@ func (o *EnsemblingJobSpec) GetPredictions() map[string]EnsemblingJobPredictionS
 // GetPredictionsOk returns a tuple with the Predictions field value
 // and a boolean to check if the value has been set.
 func (o *EnsemblingJobSpec) GetPredictionsOk() (*map[string]EnsemblingJobPredictionSource, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.Predictions, true
@@ -104,7 +104,7 @@ func (o *EnsemblingJobSpec) GetEnsembler() EnsemblingJobEnsemblerSpec {
 // GetEnsemblerOk returns a tuple with the Ensembler field value
 // and a boolean to check if the value has been set.
 func (o *EnsemblingJobSpec) GetEnsemblerOk() (*EnsemblingJobEnsemblerSpec, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.Ensembler, true
@@ -128,7 +128,7 @@ func (o *EnsemblingJobSpec) GetSink() EnsemblingJobSink {
 // GetSinkOk returns a tuple with the Sink field value
 // and a boolean to check if the value has been set.
 func (o *EnsemblingJobSpec) GetSinkOk() (*EnsemblingJobSink, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.Sink, true
@@ -191,3 +191,5 @@ func (v *NullableEnsemblingJobSpec) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
+
+

--- a/api/turing/generated/model_ensembling_resources.go
+++ b/api/turing/generated/model_ensembling_resources.go
@@ -16,10 +16,10 @@ import (
 
 // EnsemblingResources struct for EnsemblingResources
 type EnsemblingResources struct {
-	DriverCpuRequest      *string `json:"driver_cpu_request,omitempty"`
-	DriverMemoryRequest   *string `json:"driver_memory_request,omitempty"`
-	ExecutorReplica       *int32  `json:"executor_replica,omitempty"`
-	ExecutorCpuRequest    *string `json:"executor_cpu_request,omitempty"`
+	DriverCpuRequest *string `json:"driver_cpu_request,omitempty"`
+	DriverMemoryRequest *string `json:"driver_memory_request,omitempty"`
+	ExecutorReplica *int32 `json:"executor_replica,omitempty"`
+	ExecutorCpuRequest *string `json:"executor_cpu_request,omitempty"`
 	ExecutorMemoryRequest *string `json:"executor_memory_request,omitempty"`
 }
 
@@ -255,3 +255,5 @@ func (v *NullableEnsemblingResources) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
+
+

--- a/api/turing/generated/model_env_var.go
+++ b/api/turing/generated/model_env_var.go
@@ -16,7 +16,7 @@ import (
 
 // EnvVar struct for EnvVar
 type EnvVar struct {
-	Name  string  `json:"name"`
+	Name string `json:"name"`
 	Value *string `json:"value,omitempty"`
 }
 
@@ -51,7 +51,7 @@ func (o *EnvVar) GetName() string {
 // GetNameOk returns a tuple with the Name field value
 // and a boolean to check if the value has been set.
 func (o *EnvVar) GetNameOk() (*string, bool) {
-	if o == nil {
+	if o == nil  {
 		return nil, false
 	}
 	return &o.Name, true
@@ -140,3 +140,5 @@ func (v *NullableEnvVar) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
+
+

--- a/api/turing/generated/model_save_mode.go
+++ b/api/turing/generated/model_save_mode.go
@@ -21,9 +21,9 @@ type SaveMode string
 // List of SaveMode
 const (
 	SAVEMODE_ERRORIFEXISTS SaveMode = "ERRORIFEXISTS"
-	SAVEMODE_OVERWRITE     SaveMode = "OVERWRITE"
-	SAVEMODE_APPEND        SaveMode = "APPEND"
-	SAVEMODE_IGNORE        SaveMode = "IGNORE"
+	SAVEMODE_OVERWRITE SaveMode = "OVERWRITE"
+	SAVEMODE_APPEND SaveMode = "APPEND"
+	SAVEMODE_IGNORE SaveMode = "IGNORE"
 )
 
 var allowedSaveModeEnumValues = []SaveMode{
@@ -111,3 +111,4 @@ func (v *NullableSaveMode) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
+

--- a/api/turing/models/autoscaling_policy.go
+++ b/api/turing/models/autoscaling_policy.go
@@ -25,7 +25,9 @@ type AutoscalingPolicy struct {
 	// Target is the target value of the metric that should be reached to add a new replica.
 	// It is expected that the autoscaling target is an absolute value for concurrency / rps
 	// while it is a % value (of the requested value) for cpu / memory.
-	Target string `json:"target" validate:"required,number"`
+	// The 'numeric' type is used to allow decimals in strings to be set as the target value,
+	// e.g. "8.88". See https://github.com/go-playground/validator/issues/940 for more details.
+	Target string `json:"target" validate:"required,numeric"`
 }
 
 func (a AutoscalingPolicy) Value() (driver.Value, error) {

--- a/api/turing/validation/validator_test.go
+++ b/api/turing/validation/validator_test.go
@@ -1110,7 +1110,7 @@ func TestValidateAutoscaling(t *testing.T) {
 				Target: "hundred",
 			},
 			expectedError: strings.Join([]string{"Key: 'RouterConfig.AutoscalingPolicy.Target' ",
-				"Error:Field validation for 'Target' failed on the 'number' tag"}, ""),
+				"Error:Field validation for 'Target' failed on the 'numeric' tag"}, ""),
 		},
 	}
 	for name, tt := range suite {

--- a/sdk/turing/generated/model/autoscaling_policy.py
+++ b/sdk/turing/generated/model/autoscaling_policy.py
@@ -61,11 +61,6 @@ class AutoscalingPolicy(ModelNormal):
     }
 
     validations = {
-        ('target',): {
-            'regex': {
-                'pattern': r'^\d+$',  # noqa: E501
-            },
-        },
     }
 
     additional_properties_type = None


### PR DESCRIPTION
## Context
Previously in #380, the autoscaling target was refactored to allow strings with decimal places. However, this wasn't exposed (unintentionally) because the autogenerated Go/Python files from the OpenAPI specs weren't updated. This PR removes the regex check (which had previously only allowed integers as target values) in the OpenAPI specs and updates all the necessary Go/Python files as a result of that change.