### PR TITLE
fix(ui): Revert upgrade to react-lazylog

### DIFF
--- a/.github/workflows/turing.yaml
+++ b/.github/workflows/turing.yaml
@@ -180,7 +180,7 @@ jobs:
           cache-dependency-path: ui/yarn.lock
 
       - name: Install
-        run: yarn install --network-concurrency 1
+        run: NODE_OPTIONS=--openssl-legacy-provider yarn install --network-concurrency 1
 
       - name: Lint code
         run: yarn lint

--- a/ui/package.json
+++ b/ui/package.json
@@ -24,7 +24,7 @@
     "react-collapsed": "^4.1.2",
     "react-diff-viewer": "^3.1.1",
     "react-dom": "^18.3.1",
-    "react-lazylog": "^4.5.3",
+    "react-lazylog": "git+https://github.com/gojekfarm/react-lazylog#master",
     "react-router-dom": "^6.23.1",
     "react-scroll": "^1.9.0",
     "react-scroll-to-bottom": "^4.0.0",

--- a/ui/src/components/pod_logs_viewer/PodLogsViewer.js
+++ b/ui/src/components/pod_logs_viewer/PodLogsViewer.js
@@ -12,8 +12,6 @@ import { LazyLog, ScrollFollow } from "react-lazylog";
 import { slugify } from "@caraml-dev/ui-lib";
 import isArray from "lodash/isArray";
 
-import "./PodLogsViewer.scss";
-
 export const PodLogsViewer = ({
   components,
   emitter,
@@ -140,8 +138,7 @@ export const PodLogsViewer = ({
       <EuiPanel>
         <EuiFlexGroup
           direction="column"
-          gutterSize="none"
-          className="euiFlexGroup---logsContainer">
+          gutterSize="none">
           <EuiFlexItem grow={false}>
             <EuiSearchBar {...search} />
           </EuiFlexItem>
@@ -158,6 +155,7 @@ export const PodLogsViewer = ({
                   extraLines={1}
                   onScroll={onScroll}
                   follow={follow}
+                  height={640}
                   caseInsensitive
                   enableSearch
                   selectableLines

--- a/ui/src/components/pod_logs_viewer/PodLogsViewer.scss
+++ b/ui/src/components/pod_logs_viewer/PodLogsViewer.scss
@@ -1,3 +1,0 @@
-.euiFlexGroup.euiFlexGroup---logsContainer {
-  height: 640px;
-}

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -11578,10 +11578,9 @@ react-is@^18.0.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
-react-lazylog@^4.5.3:
+"react-lazylog@git+https://github.com/gojekfarm/react-lazylog#master":
   version "4.5.3"
-  resolved "https://registry.yarnpkg.com/react-lazylog/-/react-lazylog-4.5.3.tgz#289e24995b5599e75943556ac63f5e2c04d0001e"
-  integrity sha512-lyov32A/4BqihgXgtNXTHCajXSXkYHPlIEmV8RbYjHIMxCFSnmtdg4kDCI3vATz7dURtiFTvrw5yonHnrS+NNg==
+  resolved "git+https://github.com/gojekfarm/react-lazylog#e3a7f026983df0dc59d25843fe87ce7e37e24e82"
   dependencies:
     "@mattiasbuelens/web-streams-polyfill" "^0.2.0"
     fetch-readablestream "^0.2.0"


### PR DESCRIPTION
## Context
For some still yet to be understood reason, replacing the forked version of `react-lazylog` from https://github.com/gojekfarm/react-lazylog#master with the latest official version of the same package caused the logs viewer to crash due to some styling issues that get triggered when we manually set the height of the logs viewer (or the component containing it):

![Screenshot 2024-07-17 at 13 48 53](https://github.com/user-attachments/assets/29a01af4-acb2-450b-9c92-855737f9e4f9)

In the Turing UI, this height is set by the custom style in `PodLogsViewer.scss` (removed in this PR) while in the Merlin UI, it is set by passing it as a prop to the `LazyLog` component. This PR also standardises the way both UIs are setting this value.

Strangely enough, the Merlin UI isn't experiencing these styling issues even after having its `react-lazylog` replaced with the official reason but a deeper look into this will be done at a later time.