### PR TITLE
fix(ui): Fix yup validation bugs

### DIFF
--- a/.github/workflows/turing.yaml
+++ b/.github/workflows/turing.yaml
@@ -263,14 +263,6 @@ jobs:
           working-directory: api
           args: --timeout 3m --verbose
 
-      - uses: codecov/codecov-action@v4
-        with:
-          flags: api-test
-          name: api-test
-          token: ${{ secrets.CODECOV_TOKEN }}
-          working-directory: api
-          codecov_yml_path: ../.github/workflows/codecov-config/codecov.yml
-
   test-engines-router:
     runs-on: ubuntu-latest
     defaults:

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,7 +7,7 @@
   "//": "[@sentry/browser] pinned to 7.118.0 because craco/module federation has issues resolving this dependency; see",
   "//": "https://github.com/caraml-dev/turing/pull/384#discussion_r1666418144 for more details",
   "dependencies": {
-    "@caraml-dev/ui-lib": "^1.13.0-build.3-a234b6b",
+    "@caraml-dev/ui-lib": "^1.13.0-build.4-09c363a",
     "@elastic/datemath": "^5.0.3",
     "@elastic/eui": "88.2.0",
     "@emotion/css": "^11.11.2",

--- a/ui/src/components/validation.js
+++ b/ui/src/components/validation.js
@@ -1,29 +1,25 @@
 import * as yup from "yup";
 
-const httpHeaderSchema = yup
+const httpHeaderSchema = (_) => yup
   .string()
   .required('Valid Request Header value is required, e.g. "x-session-id"');
 
-const jsonPathSchema = yup
+const jsonPathSchema = (_) => yup
   .string()
-  .required(
-    'Valid Request Payload json path is required, e.g. "my_object.session_id"'
-  );
+  .required('Valid Request Payload json path is required, e.g. "my_object.session_id"');
 
-const predictionContextSchema = yup
-.string()
-.required(
-  'Valid Prediction Context value is required, e.g. "model_name"'
-);
+const predictionContextSchema = (_) => yup
+  .string()
+  .required('Valid Prediction Context value is required, e.g. "model_name"');
   
-export const fieldSourceSchema = yup
-  .mixed()
+export const fieldSourceSchema = (_) => yup
+  .string()
   .required("Valid Field Source should be selected")
   .oneOf(["header", "payload", "prediction_context"], "Valid Field Source should be selected");
 
-export const fieldSchema = (fieldSource) =>
+export const fieldSchema = (fieldSource) => (_) =>
   yup
-    .mixed()
+    .string()
     .when(fieldSource, {
       is: "header",
       then: httpHeaderSchema,

--- a/ui/src/router/components/form/components/experiment_config/components/client_config/ClientConfigPanel.js
+++ b/ui/src/router/components/form/components/experiment_config/components/client_config/ClientConfigPanel.js
@@ -74,8 +74,8 @@ export const ClientConfigPanel = ({ client, onChangeHandler, errors = {} }) => {
               content="Select your Client ID from the provided list"
             />
           }
-          isInvalid={!!errors.id}
-          error={errors.id}
+          isInvalid={!!errors.username}
+          error={errors.username}
           display="row">
           <EuiComboBoxSelect
             fullWidth

--- a/ui/src/router/components/form/components/experiment_config/validation/schema.js
+++ b/ui/src/router/components/form/components/experiment_config/validation/schema.js
@@ -15,21 +15,17 @@ const experimentSchema = yup.object().shape({
 
 const variableSchema = yup.object().shape({
   required: yup.boolean(),
-  field_source: yup.mixed().when("required", {
+  field_source: yup.string().when("required", {
     is: true,
-    then: fieldSourceSchema.required(
-      "Select the field source for the required variable"
-    ),
+    then: fieldSourceSchema,
   }),
-  field: yup.mixed().when("required", {
+  field: yup.string().when("required", {
     is: true,
-    then: fieldSchema("field_source").required(
-      "Specify the field name for the required variable"
-    ),
+    then: fieldSchema("field_source"),
   }),
 });
 
-const standardExperimentConfigSchema = (engineProps) =>
+const standardExperimentConfigSchema = (engineProps) => (_) =>
   yup.object().shape({
     client: engineProps?.standard_experiment_manager_config
       ?.client_selection_enabled

--- a/ui/src/router/components/form/validation/schema.js
+++ b/ui/src/router/components/form/validation/schema.js
@@ -148,13 +148,12 @@ const ruleConditionSchema = yup.object().shape({
     .min(1, "At least one value should be provided"),
 });
 
-const defaultTrafficRuleSchema = (_) => yup.object()
-  .shape({
-    routes: yup
-      .array()
-      .of(validRouteSchema)
-      .min(1, "At least one route should be attached to the rule"),
-  });
+const defaultTrafficRuleSchema = (_) => yup.object().shape({
+  routes: yup
+    .array()
+    .of(validRouteSchema)
+    .min(1, "At least one route should be attached to the rule"),
+});
 
 const trafficRuleSchema = yup.object().shape({
   name: yup
@@ -441,6 +440,9 @@ const schema = (maxAllowedReplica) => [
             final_response_route_id: validRouteSchema,
           }),
         }),
+        some_field: yup.string().when("some_other_field", ([some_other_field], schema) =>
+          some_other_field ? yup.string().required("this is needed") : schema
+        ),
         docker_config: yup.object().when("type", {
           is: "docker",
           then: dockerDeploymentSchema(maxAllowedReplica),

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1267,10 +1267,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@caraml-dev/ui-lib@^1.13.0-build.3-a234b6b":
-  version "1.13.0-build.3-a234b6b"
-  resolved "https://registry.yarnpkg.com/@caraml-dev/ui-lib/-/ui-lib-1.13.0-build.3-a234b6b.tgz#f24d09d00c77f1288953da8f06893970cdeeda13"
-  integrity sha512-aiOWz2QNKJ3uK8No8r9FAfHHQNHe9cvSV5Bgznj7PRaTMpJbfDDSY8U+z+B60SjdtZ7qeeTiC14cEpmv/Ot07Q==
+"@caraml-dev/ui-lib@^1.13.0-build.4-09c363a":
+  version "1.13.0-build.4-09c363a"
+  resolved "https://registry.yarnpkg.com/@caraml-dev/ui-lib/-/ui-lib-1.13.0-build.4-09c363a.tgz#c80987fa5c7989450095d354acf51a023ca94e15"
+  integrity sha512-kqb/5koS2IQtdLJIh5tk+t30ZX2GvvQO7kAuE9oKXKlwBPr83Q+lvLxcvSg+rxILYxjOUeNn2izoej0ZGMDoRg==
   dependencies:
     "@react-oauth/google" "0.12.1"
     classnames "^2.5.1"


### PR DESCRIPTION
## Context
In PR #384, the `yup` package had been updated from `0.29.1` to `1.4.0`. However, this huge upgrade had a lot of [breaking changes](https://github.com/jquense/yup/blob/master/CHANGELOG.md) (see the [latest](https://github.com/jquense/yup) README.md vs the [old](https://github.com/jquense/yup/tree/v0.29.1) one) and effectively broke most of the existing validation schemas in the Turing UI. This PR serves to fix those broken validation schemas - these changes can largely be grouped into the following:

- The `Schema.when` function has been [updated](https://github.com/jquense/yup?tab=readme-ov-file#schemawhenkeys-string--string-builder-object--values-any-schema--schema-schema), such that when the builder object (one with the fields `is`, `then`, and sometimes `otherwise` defined) is passed as an argument, the `then` field accepts ONLY functions of the following signature `(schema: Schema) => Schema` instead of `Schema` previously. 

  Existing schemas that do not follow this convention have been updated and turned into arrow functions. 
  
  Example:
  ```javascript
  // before
  some_field: yup.string().when("some_other_field", {
    is: "nop",
    then: yup.string().required("this is needed")
  }),

  // after
  some_field: yup.string().when("some_other_field", {
    is: "nop",
    then: (_) => yup.string().required("this is needed")
  }),
  ```
- When using the same `Schema.when` function but passing a function directly as an argument instead of the builder object, the signature of the expected function has also been updated from `(value, schema)=> Schema): Schema` to `(values: any[], schema) => Schema): Schema`.

  Existing schemas that do not follow this convention now have been updated to reflect the new expected array:

  Example:
  ```javascript
  // before
  some_field: yup.string().when("some_other_field", (some_other_field, schema) =>
    some_other_field ? yup.string().required("this is needed") : schema
  ),

  // after
  some_field: yup.string().when("some_other_field", ([some_other_field], schema) =>
    some_other_field ? yup.string().required("this is needed") : schema
  ),
  ```
- The `mixed` schema has been severely nerfed and is now no longer the base class for all the other schemas, and as such no longer supports a lot of the other functions that we were previously calling. Schemas that have fields which use the `mixed` schema have been updated to use a schema (e.g. `string`) corresponding to its expected primitive data type.

## Unrelated Update
This PR also bumps up the version of the `caraml-dev/ui-lib` library to the latest version.