### PR TITLE
fix(ui): Fix incorrect yup schema

### DIFF
--- a/ui/src/router/components/form/validation/schema.js
+++ b/ui/src/router/components/form/validation/schema.js
@@ -130,7 +130,7 @@ const routeSchema = yup.object().shape({
 });
 
 const validRouteSchema = yup
-  .object()
+  .string()
   .test("valid-route", "Valid route is required", function(value) {
     const configSchema = this.from.slice(-1).pop();
     const { routes } = configSchema.value.config;


### PR DESCRIPTION
## Context
This PR is a continuation of PR #387 to fix bugs with the yup schemas that are used. It simply changes the schema to the correct type of the `validRouteSchema` (it should be a string and not an object).

![image (8)](https://github.com/user-attachments/assets/b2a322d1-0de6-40c7-acf4-16abc6df1295)