### PR TITLE
fix(ui): Fix min replica yup validation schema

### DIFF
--- a/ui/src/router/components/form/validation/schema.js
+++ b/ui/src/router/components/form/validation/schema.js
@@ -221,7 +221,7 @@ const resourceRequestSchema = (maxAllowedReplica) =>
         maxAllowedReplica,
         "Max Replicas value has exceeded allowed number of replicas: ${max}"
       )
-      .when("min_replica", (minReplica, schema) =>
+      .when("min_replica", ([minReplica], schema) =>
         minReplica === 0
           ? schema.positive("Max Replica should be positive")
           : schema


### PR DESCRIPTION
## Context 
This PR introduces an additional fix to the yup validation schema, as a follow up from #387. In particular, the fix in this PR addresses this change:

- When using the same `Schema.when` function but passing a function directly as an argument instead of the builder object, the signature of the expected function has also been updated from `(value, schema)=> Schema): Schema` to `(values: any[], schema) => Schema): Schema`.

  Existing schemas that do not follow this convention now have been updated to reflect the new expected array:

  Example:
  ```javascript
  // before
  some_field: yup.string().when("some_other_field", (some_other_field, schema) =>
    some_other_field ? yup.string().required("this is needed") : schema
  ),

  // after
  some_field: yup.string().when("some_other_field", ([some_other_field], schema) =>
    some_other_field ? yup.string().required("this is needed") : schema
  ),
