### PR TITLE
chore: add managed by label to namespace

### DIFF
--- a/api/turing/api/appcontext.go
+++ b/api/turing/api/appcontext.go
@@ -81,6 +81,7 @@ func NewAppContext(
 	// Initialise Labeller
 	labeller.InitKubernetesLabeller(
 		cfg.KubernetesLabelConfigs.LabelPrefix,
+		cfg.KubernetesLabelConfigs.NamespaceLabelPrefix,
 		cfg.KubernetesLabelConfigs.Environment,
 	)
 

--- a/api/turing/cluster/controller.go
+++ b/api/turing/cluster/controller.go
@@ -11,6 +11,7 @@ import (
 	sparkclient "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
 	sparkoperatorv1beta2 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned/typed/sparkoperator.k8s.io/v1beta2" //nolint
 	mlpcluster "github.com/caraml-dev/mlp/api/pkg/cluster"
+	"github.com/caraml-dev/turing/api/turing/cluster/labeller"
 	"github.com/pkg/errors"
 	networkingv1beta1 "istio.io/client-go/pkg/clientset/versioned/typed/networking/v1beta1"
 	apiappsv1 "k8s.io/api/apps/v1"
@@ -211,7 +212,8 @@ func (c *controller) CreateNamespace(ctx context.Context, name string) error {
 	}
 	ns := apicorev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name:   name,
+			Labels: labeller.BuildNamespaceLabels(labeller.KubernetesLabelsRequest{}),
 		},
 	}
 	_, err = c.k8sCoreClient.Namespaces().Create(ctx, &ns, metav1.CreateOptions{})

--- a/api/turing/cluster/controller_test.go
+++ b/api/turing/cluster/controller_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/caraml-dev/turing/api/turing/cluster/labeller"
 	"istio.io/client-go/pkg/apis/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
@@ -1224,6 +1225,8 @@ func TestDeleteSparkApplication(t *testing.T) {
 }
 
 func TestCreateNamespace(t *testing.T) {
+	labeller.InitKubernetesLabeller("", "caraml.dev/", "")
+
 	namespace := "test-ns"
 	nsResource := schema.GroupVersionResource{
 		Version:  "v1",
@@ -1268,6 +1271,9 @@ func TestCreateNamespace(t *testing.T) {
 						expectedAction := k8stesting.NewCreateAction(nsResource, "", &corev1.Namespace{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: namespace,
+								Labels: map[string]string{
+									"caraml.dev/managed": "true",
+								},
 							},
 						})
 						assert.Equal(t, expectedAction, action)

--- a/api/turing/cluster/labeller/labeller_test.go
+++ b/api/turing/cluster/labeller/labeller_test.go
@@ -38,10 +38,10 @@ func TestLabeller(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			// Always reset singleton objects.
-			defer InitKubernetesLabeller("", "dev")
+			defer InitKubernetesLabeller("", "", "dev")
 
 			if tt.doInit {
-				InitKubernetesLabeller(tt.prefix, "dev")
+				InitKubernetesLabeller(tt.prefix, "caraml.dev/", "dev")
 			}
 
 			labels := BuildLabels(KubernetesLabelsRequest{})
@@ -121,7 +121,7 @@ func TestBuildLabels(t *testing.T) {
 
 	for _, tt := range tests {
 		// Always reset singleton objects.
-		defer InitKubernetesLabeller("", "dev")
+		defer InitKubernetesLabeller("", "", "dev")
 		t.Run(tt.name, func(t *testing.T) {
 			got := BuildLabels(tt.request)
 			if diff := cmp.Diff(got, tt.expected); diff != "" {

--- a/api/turing/config/config.go
+++ b/api/turing/config/config.go
@@ -255,6 +255,8 @@ type KubernetesLabelConfigs struct {
 	//   orchestrator: turing
 	//   app: my-model-app
 	LabelPrefix string
+	// NamespaceLabelPrefix is the prefix used for tagging kubernetes namespace.
+	NamespaceLabelPrefix string
 	// Environment is the value for the environment label
 	Environment string `validate:"required"`
 }

--- a/api/turing/service/ensembling_job_service_test.go
+++ b/api/turing/service/ensembling_job_service_test.go
@@ -648,8 +648,8 @@ func TestGetNamespaceByComponent(t *testing.T) {
 }
 
 func TestCreatePodLabelSelector(t *testing.T) {
-	labeller.InitKubernetesLabeller("prefix/", "dev")
-	defer labeller.InitKubernetesLabeller("", "dev")
+	labeller.InitKubernetesLabeller("prefix/", "", "dev")
+	defer labeller.InitKubernetesLabeller("", "", "dev")
 
 	ensemblerName := "name"
 	tests := map[string]struct {


### PR DESCRIPTION
# Context
When creating a namespace object in Kubernetes, add label “{prefix}/managed: true”. This will help when we want to modify resources created by CaraML services in a shared cluster, e.g. configuring log for the managed namespace only

# Changes

- add `NamespaceLabelPrefix` in configuration, so `InitKubernetesLabeller` can use the configured namespace prefix
- add the label when creating namespace