### PR TITLE
chore: add new label to reserved key list

### DIFF
--- a/api/turing/cluster/labeller/labeller.go
+++ b/api/turing/cluster/labeller/labeller.go
@@ -39,6 +39,7 @@ var reservedKeys = map[string]bool{
 	streamLabel:       true,
 	teamLabel:         true,
 	AppLabel:          true,
+	managedLabel:      true,
 }
 
 // ValidLabel logic reused from


### PR DESCRIPTION
## Summary

Similar changes to the one in Merlin. Previously I added a new kubernetes label in #392, this should've been added to reserved key list