### PR TITLE
chore: change webhook payload structure

### DIFF
--- a/api/turing/webhook/request.go
+++ b/api/turing/webhook/request.go
@@ -2,9 +2,31 @@ package webhook
 
 import (
 	"github.com/caraml-dev/mlp/api/pkg/webhooks"
+	"github.com/caraml-dev/turing/api/turing/models"
 )
 
 type Request struct {
-	EventType webhooks.EventType `json:"event_type"`
-	Data      interface{}        `json:"data"`
+	EventType webhooks.EventType     `json:"event_type"`
+	Data      map[string]interface{} `json:"data"`
+}
+
+// Adds the eventType to the body of the webhook request so that a single webhook endpoint is able to respond
+// differently to different event types, especially if the same webhook endpoint is configured for multiple events,
+// this is because the event type does not normally get sent to the webhook endpoint.
+func generateBody(eventType webhooks.EventType, item interface{}) *Request {
+	data := make(map[string]interface{})
+
+	switch item.(type) {
+	case *models.EnsemblerLike, models.EnsemblerLike:
+		data["ensembler"] = item
+	case *models.RouterVersion:
+		data["router_version"] = item
+	case *models.Router:
+		data["router"] = item
+	}
+
+	return &Request{
+		EventType: eventType,
+		Data:      data,
+	}
 }

--- a/api/turing/webhook/webhook.go
+++ b/api/turing/webhook/webhook.go
@@ -60,13 +60,7 @@ func (w webhook) TriggerWebhooks(ctx context.Context, eventType webhooks.EventTy
 		return nil
 	}
 
-	// Adds the eventType to the body of the webhook request so that a single webhook endpoint is able to respond
-	// differently to different event types, especially if the same webhook endpoint is configured for multiple events,
-	// This is because the event type does not normally get sent to the webhook endpoint.
-	newBody := &Request{
-		EventType: eventType,
-		Data:      body,
-	}
+	newBody := generateBody(eventType, body)
 
 	return w.webhookManager.InvokeWebhooks(
 		ctx,

--- a/api/turing/webhook/webhook_test.go
+++ b/api/turing/webhook/webhook_test.go
@@ -105,10 +105,7 @@ func Test_webhook_triggerEvent(t *testing.T) {
 			args: args{
 				ctx:       context.TODO(),
 				eventType: OnRouterCreated,
-				body: routerRequest{
-					EventType: OnRouterCreated,
-					Router:    &models.Router{},
-				},
+				body:      &models.Router{},
 			},
 			mockFunc: func(args args) {
 				mockWebhookManager.On("IsEventConfigured", args.eventType).
@@ -119,7 +116,7 @@ func Test_webhook_triggerEvent(t *testing.T) {
 					args.eventType,
 					&Request{
 						EventType: args.eventType,
-						Data:      args.body,
+						Data:      map[string]interface{}{"router": args.body},
 					},
 					mock.Anything,
 					mock.Anything,
@@ -134,10 +131,7 @@ func Test_webhook_triggerEvent(t *testing.T) {
 			args: args{
 				ctx:       context.TODO(),
 				eventType: OnRouterCreated,
-				body: routerRequest{
-					EventType: OnRouterCreated,
-					Router:    &models.Router{},
-				},
+				body:      &models.Router{},
 			},
 			mockFunc: func(args args) {
 				mockWebhookManager.On("IsEventConfigured", args.eventType).
@@ -148,7 +142,7 @@ func Test_webhook_triggerEvent(t *testing.T) {
 					args.eventType,
 					&Request{
 						EventType: args.eventType,
-						Data:      args.body,
+						Data:      map[string]interface{}{"router": args.body},
 					},
 					mock.Anything,
 					mock.Anything,


### PR DESCRIPTION
## Summary

Changing the structure of the payload send from Turing to a webhook call, so we have the same structure across [Merlin](https://github.com/caraml-dev/merlin/blob/main/api/webhook/request.go) and Turing. From
```
{
    "event_type": "on-model-endpoint-created",
    "data": {} // the data being either ensembler/router/router_version 
}
```
to
```
{
    "event_type": "on-model-endpoint-created",
    "data": {
        "ensembler": {}, // omit if empty
        "router": {}, // omit if empty
        "router_version": {} // omit if empty
    }
}
```
I make the payload with this structure in case in the future we want to put several object in the payload (instead of just one object like now). I’m open to any advice if you have other opinions  