### PR TITLE
feat(image-builder): Add mechanism to pass api server env vars to kaniko build jobs

### DIFF
--- a/api/turing/config/config.go
+++ b/api/turing/config/config.go
@@ -445,7 +445,7 @@ type MlflowConfig struct {
 	// --build-arg=[AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_DEFAULT_REGION/AWS_ENDPOINT_URL]=xxx
 	// OR
 	// 2) additional arguments in the config KanikoConfig.APIServerEnvVars, which will pass the specified environment
-	// variables PRESENT within the Merlin API server's container to the image builder as build arguments
+	// variables PRESENT within the Turing API server's container to the image builder as build arguments
 	ArtifactServiceType string `validate:"required,oneof=nop gcs s3"`
 }
 

--- a/api/turing/config/config.go
+++ b/api/turing/config/config.go
@@ -444,8 +444,8 @@ type MlflowConfig struct {
 	// 1) additional arguments in the config KanikoConfig.AdditionalArgs e.g.
 	// --build-arg=[AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_DEFAULT_REGION/AWS_ENDPOINT_URL]=xxx
 	// OR
-	// 2) additional arguments in the config KanikoConfig.APIServerEnvVars, which will pass the specified environment variables
-	// PRESENT within the Merlin API server's container to the image builder as build arguments
+	// 2) additional arguments in the config KanikoConfig.APIServerEnvVars, which will pass the specified environment
+	// variables PRESENT within the Merlin API server's container to the image builder as build arguments
 	ArtifactServiceType string `validate:"required,oneof=nop gcs s3"`
 }
 

--- a/api/turing/config/config.go
+++ b/api/turing/config/config.go
@@ -208,6 +208,8 @@ type KanikoConfig struct {
 	ImageVersion string `validate:"required"`
 	// AdditionalArgs allows platform-level additional arguments to be configured for Kaniko jobs
 	AdditionalArgs []string
+	// APIServerEnvVars allows extra API-server environment variables to be passed to Kaniko jobs
+	APIServerEnvVars []string
 	// Kaniko kubernetes service account
 	ServiceAccount string
 	// ResourceRequestsLimits is the resources required by Kaniko executor.
@@ -439,8 +441,11 @@ type MlflowConfig struct {
 	// Note that the Kaniko image builder needs to be configured correctly to have the necessary credentials to download
 	// the artifacts from the blob storage tool depending on the artifact service type selected (gcs/s3). For gcs, the
 	// credentials can be provided via a k8s service account or a secret but for s3, the credentials can be provided via
-	// additional arguments in the config KanikoConfig.AdditionalArgs e.g.
+	// 1) additional arguments in the config KanikoConfig.AdditionalArgs e.g.
 	// --build-arg=[AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_DEFAULT_REGION/AWS_ENDPOINT_URL]=xxx
+	// OR
+	// 2) additional arguments in the config KanikoConfig.APIServerEnvVars, which will pass the specified environment variables
+	// PRESENT within the Merlin API server's container to the image builder as build arguments
 	ArtifactServiceType string `validate:"required,oneof=nop gcs s3"`
 }
 

--- a/api/turing/imagebuilder/imagebuilder.go
+++ b/api/turing/imagebuilder/imagebuilder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -319,6 +320,11 @@ func (ib *imageBuilder) createKanikoJob(
 	kanikoArgs = ib.configureKanikoArgsToAddCredentials(kanikoArgs)
 	volumes, volumeMounts = ib.configureVolumesAndVolumeMountsToAddCredentials(volumes, volumeMounts)
 	envVars = ib.configureEnvVarsToAddCredentials(envVars)
+
+	// Add all other env vars that are propagated from the API server as build args
+	for _, envVar := range ib.imageBuildingConfig.KanikoConfig.APIServerEnvVars {
+		kanikoArgs = append(kanikoArgs, fmt.Sprintf("--build-arg=%s=%s", envVar, os.Getenv(envVar)))
+	}
 
 	job := cluster.Job{
 		Name:                    kanikoJobName,


### PR DESCRIPTION
## Context
Similar to what had been performed for Merlin in this PR https://github.com/caraml-dev/merlin/pull/621, this PR introduces a new mechanism for environment variables from the Turing API server to be propagated to **_the build environment of the Kaniko build jobs_** that it spins up, reducing the need for redundant repetition of configuration, especially if these environment variables are common to both the Turing API server and the build environment of the Kaniko build jobs.

Since these variables are passed to the Kaniko build jobs as build arguments (as opposed to environment variables of the container where the image gets built; see https://github.com/GoogleContainerTools/kaniko/issues/2824 for more details), these variables get passed as additional arguments in the Kaniko build job.

## Modifications
- `api/turing/config/config.go` - Addition of configs to specify environment variables to pass from the Turing API server to the Kaniko job
- `api/turing/imagebuilder/imagebuilder.go` - Addition of a step to add Turing API server environment variables as Kaniko build args
