### PR TITLE
fix(api): Add configmaps as a resource to the spark driver role rules

### DIFF
--- a/api/turing/cluster/spark.go
+++ b/api/turing/cluster/spark.go
@@ -71,6 +71,18 @@ var DefaultSparkDriverRoleRules = []apirbacv1.PolicyRule{
 			"*",
 		},
 	},
+	{
+		// Allow driver to manage configmaps
+		APIGroups: []string{
+			"", // indicates the core API group
+		},
+		Resources: []string{
+			"configmaps",
+		},
+		Verbs: []string{
+			"*",
+		},
+	},
 }
 
 // CreateSparkRequest is the request for creating a spark driver


### PR DESCRIPTION
## Context
Similar to https://github.com/caraml-dev/merlin/pull/623, currently, the Spark driver service account that is created for every batch ensembling job does not have permissions to create ConfigMaps that its Spark executor(s) require(s). This is a problem in clusters with RBAC enabled and this PR simply adds the missing rule on ConfigMap resources for the Spark driver service account.

## Modifications
- `api/turing/cluster/spark.go` - Addition of configmaps as an additional rule