### PR TITLE
feat(batch-jobs): Add step to pass API server env vars to spark jobs

### DIFF
--- a/api/turing/cluster/spark.go
+++ b/api/turing/cluster/spark.go
@@ -304,5 +304,5 @@ func getEnvVars(request *CreateSparkRequest) []apicorev1.EnvVar {
 		envVars = append(envVars, apicorev1.EnvVar{Name: ev, Value: os.Getenv(ev)})
 	}
 
-	return append(defaultEnvVars, getEnvVarFromRequest(request)...)
+	return append(envVars, getEnvVarFromRequest(request)...)
 }

--- a/api/turing/cluster/spark.go
+++ b/api/turing/cluster/spark.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 
 	apisparkv1beta2 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
@@ -192,7 +193,7 @@ func createSparkExecutor(request *CreateSparkRequest) (*apisparkv1beta2.Executor
 					Path: serviceAccountMount,
 				},
 			},
-			Env:    append(defaultEnvVars, getEnvVarFromRequest(request)...),
+			Env:    getEnvVars(request),
 			Labels: request.JobLabels,
 		},
 	}
@@ -242,7 +243,7 @@ func createSparkDriver(request *CreateSparkRequest) (*apisparkv1beta2.DriverSpec
 					Path: serviceAccountMount,
 				},
 			},
-			Env:            append(defaultEnvVars, getEnvVarFromRequest(request)...),
+			Env:            getEnvVars(request),
 			Labels:         request.JobLabels,
 			ServiceAccount: &request.ServiceAccountName,
 		},
@@ -294,4 +295,14 @@ func toMegabyte(request string) (*string, error) {
 	inMegaBytes := inBytes / (1024 * 1024)
 	strVal := fmt.Sprintf("%sm", strconv.Itoa(int(inMegaBytes)))
 	return &strVal, nil
+}
+
+func getEnvVars(request *CreateSparkRequest) []apicorev1.EnvVar {
+	envVars := defaultEnvVars
+
+	for _, ev := range request.SparkInfraConfig.APIServerEnvVars {
+		envVars = append(envVars, apicorev1.EnvVar{Name: ev, Value: os.Getenv(ev)})
+	}
+
+	return append(defaultEnvVars, getEnvVarFromRequest(request)...)
 }

--- a/api/turing/config/config.go
+++ b/api/turing/config/config.go
@@ -223,6 +223,7 @@ type KanikoConfig struct {
 // SparkAppConfig contains the infra configurations that is unique to the user's Kubernetes
 type SparkAppConfig struct {
 	NodeSelector                   map[string]string
+	APIServerEnvVars               []string
 	CorePerCPURequest              float64 `validate:"required"`
 	CPURequestToCPULimit           float64 `validate:"required"`
 	SparkVersion                   string  `validate:"required"`


### PR DESCRIPTION
## Context
Similar to https://github.com/caraml-dev/merlin/pull/624, this simple PR simply adds a tiny feature to allow the API server to pass certain pre-configured environment variable values from its environment to the Spark drivers and executors (for batch prediction) that it spins up.

## Modifications
- `api/turing/cluster/spark.go` - Addition of a step to add pre-configured API server environment variables to the Spark driver/executor manifest
- `api/turing/config/config.go` - Addition of a new config field to specify the environment values mentioned above