### PR TITLE
chore: increase log volume size

### DIFF
--- a/api/turing/cluster/labeller/labeller.go
+++ b/api/turing/cluster/labeller/labeller.go
@@ -22,7 +22,7 @@ const (
 	// AppLabel refers to application of the Kubernetes Object
 	AppLabel = "app"
 	// managedLabel mark the kubernetes object as being managed by specific dev
-	managedLabel = "managed"
+	managedLabel = "caraml.dev/managed"
 )
 
 var (

--- a/api/turing/cluster/labeller/labeller.go
+++ b/api/turing/cluster/labeller/labeller.go
@@ -22,7 +22,7 @@ const (
 	// AppLabel refers to application of the Kubernetes Object
 	AppLabel = "app"
 	// managedLabel mark the kubernetes object as being managed by specific dev
-	managedLabel = "caraml.dev/managed"
+	managedLabel = "managed"
 )
 
 var (

--- a/api/turing/cluster/servicebuilder/fluentd.go
+++ b/api/turing/cluster/servicebuilder/fluentd.go
@@ -20,7 +20,7 @@ const (
 	fluentdMemRequest    = "1Gi"
 	fluentdPort          = 24224
 	cacheVolumeMountPath = "/cache/"
-	cacheVolumeSize      = "2Gi"
+	cacheVolumeSize      = "10Gi"
 
 	// defaultCPULimitRequestFactor is the default multiplication factor applied to the CPU request,
 	// to be set as the limit

--- a/api/turing/cluster/servicebuilder/fluentd.go
+++ b/api/turing/cluster/servicebuilder/fluentd.go
@@ -20,7 +20,7 @@ const (
 	fluentdMemRequest    = "1Gi"
 	fluentdPort          = 24224
 	cacheVolumeMountPath = "/cache/"
-	cacheVolumeSize      = "10Gi"
+	cacheVolumeSize      = "20Gi"
 
 	// defaultCPULimitRequestFactor is the default multiplication factor applied to the CPU request,
 	// to be set as the limit


### PR DESCRIPTION
In certain environments there is a constraint for logger volume, setting the default value to 20Gi