### PR TITLE
chore: retrieve google sa in ensembling job only if it's specified

### DIFF
--- a/api/turing/batch/ensembling/controller.go
+++ b/api/turing/batch/ensembling/controller.go
@@ -315,7 +315,7 @@ func (c *ensemblingController) getMLPSecrets(
 		}
 		secretMap[cluster.ServiceAccountFileName] = secretString
 	}
-	
+
 	// Retrieve user-configured secrets from MLP
 	if ensemblingJob.InfraConfig.Secrets != nil {
 		for _, secret := range *ensemblingJob.InfraConfig.Secrets {

--- a/api/turing/batch/ensembling/controller.go
+++ b/api/turing/batch/ensembling/controller.go
@@ -303,19 +303,23 @@ func (c *ensemblingController) getMLPSecrets(
 ) (map[string]string, error) {
 	secretMap := make(map[string]string)
 	// Retrieve Google Service Account secret from MLP
-	secretString, err := c.mlpService.GetSecret(
-		ensemblingJob.ProjectID,
-		ensemblingJob.InfraConfig.GetServiceAccountName(),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("service account %s is not found within %s project: %w",
-			ensemblingJob.InfraConfig.GetServiceAccountName(), namespace, err)
+	// Retrieve Google Service Account secret from MLP
+	if ensemblingJob.InfraConfig.GetServiceAccountName() != "" {
+		secretString, err := c.mlpService.GetSecret(
+			ensemblingJob.ProjectID,
+			ensemblingJob.InfraConfig.GetServiceAccountName(),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("service account %s is not found within %s project: %w",
+				ensemblingJob.InfraConfig.GetServiceAccountName(), namespace, err)
+		}
+		secretMap[cluster.ServiceAccountFileName] = secretString
 	}
-	secretMap[cluster.ServiceAccountFileName] = secretString
+	
 	// Retrieve user-configured secrets from MLP
 	if ensemblingJob.InfraConfig.Secrets != nil {
 		for _, secret := range *ensemblingJob.InfraConfig.Secrets {
-			secretString, err = c.mlpService.GetSecret(
+			secretString, err := c.mlpService.GetSecret(
 				ensemblingJob.ProjectID,
 				secret.GetMlpSecretName(),
 			)

--- a/api/turing/batch/ensembling/controller.go
+++ b/api/turing/batch/ensembling/controller.go
@@ -303,7 +303,6 @@ func (c *ensemblingController) getMLPSecrets(
 ) (map[string]string, error) {
 	secretMap := make(map[string]string)
 	// Retrieve Google Service Account secret from MLP
-	// Retrieve Google Service Account secret from MLP
 	if ensemblingJob.InfraConfig.GetServiceAccountName() != "" {
 		secretString, err := c.mlpService.GetSecret(
 			ensemblingJob.ProjectID,


### PR DESCRIPTION
## Modification

Adding a check to retrieve the Google service account in ensembling job creation only if the account name is provided