### PR TITLE
add fetch depth option to checkout actions

### DIFF
--- a/.github/workflows/pyfunc-ensembler-job.yaml
+++ b/.github/workflows/pyfunc-ensembler-job.yaml
@@ -16,6 +16,8 @@ jobs:
         python-version: ["3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -48,6 +50,8 @@ jobs:
       release-type: ${{ steps.release-rules.outputs.release-type }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - id: release-rules
         uses: ./.github/actions/release-rules
         with:

--- a/.github/workflows/pyfunc-ensembler-service.yaml
+++ b/.github/workflows/pyfunc-ensembler-service.yaml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -40,6 +42,8 @@ jobs:
       release-type: ${{ steps.release-rules.outputs.release-type }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - id: release-rules
         uses: ./.github/actions/release-rules
         with:


### PR DESCRIPTION
The MR adds fetch-depth option to checkout@v4 actions, thus pulling the whole repo in the gitlab pipeline