### PR TITLE
fix(ensembler): Add pipenv installation

### DIFF
--- a/engines/pyfunc-ensembler-job/Makefile
+++ b/engines/pyfunc-ensembler-job/Makefile
@@ -10,6 +10,7 @@ setup: build
 	@DIST_VERSION=$$(echo $(VERSION) | \
 		sed -E 's/^v([0-9]+\.[0-9]+\.[0-9]+)(-rc([0-9]+))?/\1rc\3/'); \
 		$(ACTIVATE_ENV) && pip install "dist/turing_pyfunc_ensembler_job-$${DIST_VERSION}-py3-none-any.whl[dev]"
+	@pip install pipenv
 
 .PHONY: type-check
 type-check:

--- a/engines/pyfunc-ensembler-service/Makefile
+++ b/engines/pyfunc-ensembler-service/Makefile
@@ -10,6 +10,7 @@ setup: build
 	@DIST_VERSION=$$(echo $(VERSION) | \
 		sed -E 's/^v([0-9]+\.[0-9]+\.[0-9]+)(-rc([0-9]+))?/\1rc\3/'); \
 		$(ACTIVATE_ENV) && pip install "dist/turing_pyfunc_ensembler_service-$${DIST_VERSION}-py3-none-any.whl[dev]"
+	@pip install pipenv
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
## Context
It appears that the ensembler job/service setup steps now could no longer run because `pipenv` somehow present in the environment where they run in do not have `pipenv` preinstalled. This PR simply adds a step to the setup Makefile recipe to explicitly install `pipenv`.