### PR TITLE
fix(ensembler): Remove all pipenv usage

### DIFF
--- a/engines/pyfunc-ensembler-job/Makefile
+++ b/engines/pyfunc-ensembler-job/Makefile
@@ -10,11 +10,15 @@ setup: build
 	@DIST_VERSION=$$(echo $(VERSION) | \
 		sed -E 's/^v([0-9]+\.[0-9]+\.[0-9]+)(-rc([0-9]+))?/\1rc\3/'); \
 		$(ACTIVATE_ENV) && pip install "dist/turing_pyfunc_ensembler_job-$${DIST_VERSION}-py3-none-any.whl[dev]"
-	@pip install pipenv
 
 .PHONY: type-check
 type-check:
-	@pipenv run mypy --ignore-missing-imports --allow-untyped-globals --implicit-optional ensembler --follow-imports silent
+	@$(ACTIVATE_ENV) && mypy \
+		--install-types \
+		--non-interactive \
+		--ignore-missing-imports \
+		--allow-untyped-globals \
+		ensembler
 
 .PHONY: lint
 lint:
@@ -24,7 +28,11 @@ lint:
 
 .PHONY: test
 test: type-check
-	@pipenv run pytest -W ignore
+	@$(ACTIVATE_ENV) && \
+		python -m pytest \
+		--cov=ensembler \
+		--ignore=env \
+		-W ignore
 
 .PHONY: build-image
 build-image: version

--- a/engines/pyfunc-ensembler-job/requirements.txt
+++ b/engines/pyfunc-ensembler-job/requirements.txt
@@ -2,7 +2,7 @@ cloudpickle==2.0.0
 google-cloud-storage>=1.37.0
 jinjasql==0.1.8
 jinja2==3.0.3
-numpy==1.22.0
+numpy>=1.22.0
 pandas==1.3.5
 py4j==0.10.9
 pyarrow>=0.14.1,<=9.0.0

--- a/engines/pyfunc-ensembler-service/Makefile
+++ b/engines/pyfunc-ensembler-service/Makefile
@@ -10,7 +10,6 @@ setup: build
 	@DIST_VERSION=$$(echo $(VERSION) | \
 		sed -E 's/^v([0-9]+\.[0-9]+\.[0-9]+)(-rc([0-9]+))?/\1rc\3/'); \
 		$(ACTIVATE_ENV) && pip install "dist/turing_pyfunc_ensembler_service-$${DIST_VERSION}-py3-none-any.whl[dev]"
-	@pip install pipenv
 
 .PHONY: lint
 lint:
@@ -20,7 +19,11 @@ lint:
 
 .PHONY: test
 test:
-	@pipenv run pytest -W ignore
+	@$(ACTIVATE_ENV) && \
+		python -m pytest \
+		--cov=pyfunc_ensembler_runner \
+		--cov-report term-missing \
+		-W ignore
 
 .PHONY: build-image
 build-image: version

--- a/engines/pyfunc-ensembler-service/tests/conftest.py
+++ b/engines/pyfunc-ensembler-service/tests/conftest.py
@@ -17,17 +17,6 @@ class TestEnsembler(PyFunc):
             return kwargs
 
 
-class LegacyEnsembler(PyFunc):
-    def initialize(self, artifacts: Dict):
-        pass
-
-    def ensemble(self, input: Dict, predictions: Dict, treatment_config: Dict) -> Any:
-        if treatment_config["configuration"]["name"] == "choose_the_control":
-            return predictions["control"]["data"]["predictions"]
-        else:
-            return [0, 0]
-
-
 def get_ensembler_path(model):
     import os
     import mlflow
@@ -49,8 +38,3 @@ def get_ensembler_path(model):
 @pytest.fixture
 def simple_ensembler_uri():
     return get_ensembler_path(TestEnsembler())
-
-
-@pytest.fixture
-def legacy_ensembler_uri():
-    return get_ensembler_path(LegacyEnsembler())

--- a/engines/pyfunc-ensembler-service/tests/test_ensembler_runner.py
+++ b/engines/pyfunc-ensembler-service/tests/test_ensembler_runner.py
@@ -27,11 +27,7 @@ with open(os.path.join(data_dir, "request_invalid.json")) as f:
             "simple_ensembler_uri",
             dummy_short_request,
             {"Key": "Value"},
-            {"headers": {"Key": "Value"}},
-        ),
-        pytest.param("legacy_ensembler_uri", dummy_long_request, {}, [296.15732, 0]),
-        pytest.param(
-            "legacy_ensembler_uri", dummy_short_request, {"Key": "Value"}, [0, 0]
+            {"headers": {"Key": "Value"}, "enricher_response" : None},
         ),
     ],
 )


### PR DESCRIPTION
## Context 
Unlike what was mentioned in #411, there was no need for Turing to be using `pipenv` at all as it was already originally using conda as a package manager. This PR removes all instances where `pipenv` was used and replaces it with what was originally there before #404.